### PR TITLE
feat: add scoring engine and storage model

### DIFF
--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -1,0 +1,9 @@
+export const TARGET_SCORE = 1000
+export const DOUBLE_VICTORY_SCORE = 200
+export const SMALL_TICHU_BONUS = 100
+export const GRAND_TICHU_BONUS = 200
+export const NORMAL_ROUND_TOTAL_POINTS = 100
+
+export const SEATS = ['north', 'east', 'south', 'west'] as const
+export const PLAYER_IDS = ['player-1', 'player-2', 'player-3', 'player-4'] as const
+export const TEAM_IDS = ['north-south', 'east-west'] as const

--- a/src/domain/defaults.ts
+++ b/src/domain/defaults.ts
@@ -1,0 +1,28 @@
+import { PLAYER_IDS, SEATS } from './constants'
+import type { GameSettings, Player, PlayerTichuCallMap } from './types'
+
+const DEFAULT_PLAYER_NAMES = ['Phoenix', 'Dragon', 'Pagoda', 'Jade'] as const
+
+export function createDefaultPlayers(): Player[] {
+  return PLAYER_IDS.map((id, index) => ({
+    id,
+    name: DEFAULT_PLAYER_NAMES[index],
+    seat: SEATS[index],
+  }))
+}
+
+export function createDefaultTichuCalls(): PlayerTichuCallMap {
+  return {
+    'player-1': 'none',
+    'player-2': 'none',
+    'player-3': 'none',
+    'player-4': 'none',
+  }
+}
+
+export function createDefaultSettings(): GameSettings {
+  return {
+    language: 'en',
+    theme: 'system',
+  }
+}

--- a/src/domain/helpers.ts
+++ b/src/domain/helpers.ts
@@ -1,0 +1,17 @@
+import { TEAM_IDS } from './constants'
+import type { Player, PlayerId, Seat, TeamId, TeamScoreMap } from './types'
+
+export function getTeamIdBySeat(seat: Seat): TeamId {
+  return seat === 'north' || seat === 'south' ? TEAM_IDS[0] : TEAM_IDS[1]
+}
+
+export function createEmptyTeamScoreMap(): TeamScoreMap {
+  return {
+    'north-south': 0,
+    'east-west': 0,
+  }
+}
+
+export function getPlayerById(players: Player[], playerId: PlayerId): Player | undefined {
+  return players.find((player) => player.id === playerId)
+}

--- a/src/domain/scoring.test.ts
+++ b/src/domain/scoring.test.ts
@@ -1,0 +1,120 @@
+import { createDefaultPlayers, createDefaultTichuCalls } from './defaults'
+import {
+  calculateCumulativeScores,
+  calculateRoundScore,
+  getGameStatus,
+  validateRoundInput,
+} from './scoring'
+
+describe('scoring', () => {
+  it('scores a successful small tichu for the first-out player', () => {
+    const players = createDefaultPlayers()
+    const calls = createDefaultTichuCalls()
+    calls['player-1'] = 'small'
+
+    const result = calculateRoundScore(players, {
+      tichuCalls: calls,
+      firstOutPlayerId: 'player-1',
+      doubleVictoryTeamId: null,
+      cardPoints: {
+        'north-south': 60,
+        'east-west': 40,
+      },
+    })
+
+    expect(result.tichuBonuses['north-south']).toBe(100)
+    expect(result.roundTotals['north-south']).toBe(160)
+    expect(result.roundTotals['east-west']).toBe(40)
+    expect(result.callResults[0]?.succeeded).toBe(true)
+  })
+
+  it('scores a failed grand tichu against the caller team', () => {
+    const players = createDefaultPlayers()
+    const calls = createDefaultTichuCalls()
+    calls['player-2'] = 'grand'
+
+    const result = calculateRoundScore(players, {
+      tichuCalls: calls,
+      firstOutPlayerId: 'player-1',
+      doubleVictoryTeamId: null,
+      cardPoints: {
+        'north-south': 55,
+        'east-west': 45,
+      },
+    })
+
+    expect(result.tichuBonuses['east-west']).toBe(-200)
+    expect(result.roundTotals['east-west']).toBe(-155)
+    expect(result.callResults[0]?.succeeded).toBe(false)
+  })
+
+  it('uses the double victory score and ignores card points', () => {
+    const players = createDefaultPlayers()
+
+    const result = calculateRoundScore(players, {
+      tichuCalls: createDefaultTichuCalls(),
+      firstOutPlayerId: 'player-1',
+      doubleVictoryTeamId: 'east-west',
+      cardPoints: null,
+    })
+
+    expect(result.cardPoints).toEqual({
+      'north-south': 0,
+      'east-west': 200,
+    })
+    expect(result.roundTotals['east-west']).toBe(200)
+  })
+
+  it('calculates cumulative totals across rounds', () => {
+    const players = createDefaultPlayers()
+
+    const firstRound = calculateRoundScore(players, {
+      tichuCalls: createDefaultTichuCalls(),
+      firstOutPlayerId: 'player-1',
+      doubleVictoryTeamId: null,
+      cardPoints: {
+        'north-south': 70,
+        'east-west': 30,
+      },
+    })
+
+    const secondRound = calculateRoundScore(players, {
+      tichuCalls: createDefaultTichuCalls(),
+      firstOutPlayerId: 'player-2',
+      doubleVictoryTeamId: 'east-west',
+      cardPoints: null,
+    })
+
+    expect(calculateCumulativeScores([firstRound, secondRound])).toEqual({
+      'north-south': 70,
+      'east-west': 230,
+    })
+  })
+
+  it('requires another round when both teams tie above 1000', () => {
+    expect(
+      getGameStatus({
+        'north-south': 1020,
+        'east-west': 1020,
+      }),
+    ).toEqual({
+      isGameOver: false,
+      winnerTeamId: null,
+      tieBreakRequired: true,
+    })
+  })
+
+  it('validates that normal round card points total 100', () => {
+    const validation = validateRoundInput(createDefaultPlayers(), {
+      tichuCalls: createDefaultTichuCalls(),
+      firstOutPlayerId: 'player-1',
+      doubleVictoryTeamId: null,
+      cardPoints: {
+        'north-south': 80,
+        'east-west': 50,
+      },
+    })
+
+    expect(validation.ok).toBe(false)
+  })
+})

--- a/src/domain/scoring.ts
+++ b/src/domain/scoring.ts
@@ -1,0 +1,187 @@
+import {
+  DOUBLE_VICTORY_SCORE,
+  GRAND_TICHU_BONUS,
+  NORMAL_ROUND_TOTAL_POINTS,
+  SMALL_TICHU_BONUS,
+  TARGET_SCORE,
+} from './constants'
+import { createEmptyTeamScoreMap, getPlayerById, getTeamIdBySeat } from './helpers'
+import type {
+  GameStatus,
+  Player,
+  RoundInput,
+  RoundScoreBreakdown,
+  RoundValidationError,
+  RoundValidationResult,
+  TeamId,
+  TeamScoreMap,
+  TichuCallResult,
+} from './types'
+
+export function validateRoundInput(players: Player[], input: RoundInput): RoundValidationResult {
+  const errors: RoundValidationError[] = []
+
+  if (players.length !== 4) {
+    errors.push({
+      field: 'players',
+      message: 'Exactly four players are required.',
+    })
+  }
+
+  const firstOutPlayer = getPlayerById(players, input.firstOutPlayerId)
+
+  if (!firstOutPlayer) {
+    errors.push({
+      field: 'first-out',
+      message: 'The first-out player must exist in the current party.',
+    })
+  }
+
+  if (input.doubleVictoryTeamId) {
+    if (input.cardPoints !== null) {
+      errors.push({
+        field: 'double-victory',
+        message: 'Card points must be empty when double victory is active.',
+      })
+    }
+  } else {
+    if (!input.cardPoints) {
+      errors.push({
+        field: 'card-points',
+        message: 'Card points are required for a normal round.',
+      })
+    } else if (
+      input.cardPoints['north-south'] + input.cardPoints['east-west'] !==
+      NORMAL_ROUND_TOTAL_POINTS
+    ) {
+      errors.push({
+        field: 'card-points',
+        message: 'Card points must total 100 in a normal round.',
+      })
+    }
+  }
+
+  return errors.length > 0 ? { ok: false, errors } : { ok: true }
+}
+
+export function calculateRoundScore(players: Player[], input: RoundInput): RoundScoreBreakdown {
+  const validation = validateRoundInput(players, input)
+
+  if (!validation.ok) {
+    throw new Error(validation.errors.map((error) => error.message).join(' '))
+  }
+
+  const cardPoints = createCardPointTotals(input)
+  const tichuBonuses = createEmptyTeamScoreMap()
+  const callResults: TichuCallResult[] = []
+  const firstOutPlayer = getPlayerById(players, input.firstOutPlayerId)
+
+  if (!firstOutPlayer) {
+    throw new Error('The first-out player could not be resolved.')
+  }
+
+  for (const player of players) {
+    const call = input.tichuCalls[player.id]
+
+    if (call === 'none') {
+      continue
+    }
+
+    const scoreValue = call === 'small' ? SMALL_TICHU_BONUS : GRAND_TICHU_BONUS
+    const succeeded = player.id === firstOutPlayer.id
+    const scoreDelta = succeeded ? scoreValue : -scoreValue
+    const teamId = getTeamIdBySeat(player.seat)
+
+    tichuBonuses[teamId] += scoreDelta
+    callResults.push({
+      playerId: player.id,
+      teamId,
+      call,
+      succeeded,
+      scoreDelta,
+    })
+  }
+
+  return {
+    cardPoints,
+    tichuBonuses,
+    roundTotals: addTeamScores(cardPoints, tichuBonuses),
+    callResults,
+  }
+}
+
+export function calculateCumulativeScores(rounds: RoundScoreBreakdown[]): TeamScoreMap {
+  return rounds.reduce(
+    (totals, round) => addTeamScores(totals, round.roundTotals),
+    createEmptyTeamScoreMap(),
+  )
+}
+
+export function getGameStatus(teamScores: TeamScoreMap): GameStatus {
+  const northSouthReached = teamScores['north-south'] >= TARGET_SCORE
+  const eastWestReached = teamScores['east-west'] >= TARGET_SCORE
+
+  if (!northSouthReached && !eastWestReached) {
+    return {
+      isGameOver: false,
+      winnerTeamId: null,
+      tieBreakRequired: false,
+    }
+  }
+
+  if (northSouthReached && eastWestReached) {
+    if (teamScores['north-south'] === teamScores['east-west']) {
+      return {
+        isGameOver: false,
+        winnerTeamId: null,
+        tieBreakRequired: true,
+      }
+    }
+
+    return {
+      isGameOver: true,
+      winnerTeamId:
+        teamScores['north-south'] > teamScores['east-west'] ? 'north-south' : 'east-west',
+      tieBreakRequired: false,
+    }
+  }
+
+  return {
+    isGameOver: true,
+    winnerTeamId: northSouthReached ? 'north-south' : 'east-west',
+    tieBreakRequired: false,
+  }
+}
+
+function createCardPointTotals(input: RoundInput): TeamScoreMap {
+  if (input.doubleVictoryTeamId) {
+    return {
+      'north-south': input.doubleVictoryTeamId === 'north-south' ? DOUBLE_VICTORY_SCORE : 0,
+      'east-west': input.doubleVictoryTeamId === 'east-west' ? DOUBLE_VICTORY_SCORE : 0,
+    }
+  }
+
+  if (!input.cardPoints) {
+    throw new Error('Card points are required when double victory is not active.')
+  }
+
+  return {
+    'north-south': input.cardPoints['north-south'],
+    'east-west': input.cardPoints['east-west'],
+  }
+}
+
+function addTeamScores(left: TeamScoreMap, right: TeamScoreMap): TeamScoreMap {
+  return {
+    'north-south': left['north-south'] + right['north-south'],
+    'east-west': left['east-west'] + right['east-west'],
+  }
+}
+
+export function getLeadingTeamId(teamScores: TeamScoreMap): TeamId | null {
+  if (teamScores['north-south'] === teamScores['east-west']) {
+    return null
+  }
+
+  return teamScores['north-south'] > teamScores['east-west'] ? 'north-south' : 'east-west'
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,83 @@
+import type { NORMAL_ROUND_TOTAL_POINTS, PLAYER_IDS, SEATS, TEAM_IDS } from './constants'
+
+export type Seat = (typeof SEATS)[number]
+export type PlayerId = (typeof PLAYER_IDS)[number]
+export type TeamId = (typeof TEAM_IDS)[number]
+export type TichuCall = 'none' | 'small' | 'grand'
+export type Language = 'en' | 'ko'
+export type ThemeMode = 'system' | 'light' | 'dark'
+
+export type Player = {
+  id: PlayerId
+  name: string
+  seat: Seat
+}
+
+export type TeamScoreMap = Record<TeamId, number>
+export type PlayerTichuCallMap = Record<PlayerId, TichuCall>
+
+export type RoundInput = {
+  tichuCalls: PlayerTichuCallMap
+  firstOutPlayerId: PlayerId
+  doubleVictoryTeamId: TeamId | null
+  cardPoints: TeamScoreMap | null
+}
+
+export type TichuCallResult = {
+  playerId: PlayerId
+  teamId: TeamId
+  call: Exclude<TichuCall, 'none'>
+  succeeded: boolean
+  scoreDelta: number
+}
+
+export type RoundScoreBreakdown = {
+  cardPoints: TeamScoreMap
+  tichuBonuses: TeamScoreMap
+  roundTotals: TeamScoreMap
+  callResults: TichuCallResult[]
+}
+
+export type RoundValidationError = {
+  field: 'players' | 'first-out' | 'double-victory' | 'card-points'
+  message: string
+}
+
+export type RoundValidationResult =
+  | { ok: true }
+  | {
+      ok: false
+      errors: RoundValidationError[]
+    }
+
+export type RoundRecord = {
+  id: string
+  input: RoundInput
+  result: RoundScoreBreakdown
+}
+
+export type GameStatus =
+  | {
+      isGameOver: false
+      winnerTeamId: null
+      tieBreakRequired: boolean
+    }
+  | {
+      isGameOver: true
+      winnerTeamId: TeamId
+      tieBreakRequired: false
+    }
+
+export type GameSettings = {
+  language: Language
+  theme: ThemeMode
+}
+
+export type PersistedGameState = {
+  schemaVersion: 1
+  players: Player[]
+  rounds: RoundRecord[]
+  settings: GameSettings
+}
+
+export type NormalRoundTotal = typeof NORMAL_ROUND_TOTAL_POINTS

--- a/src/storage/game-storage.test.ts
+++ b/src/storage/game-storage.test.ts
@@ -1,0 +1,51 @@
+import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
+import type { PersistedGameState } from '../domain/types'
+import {
+  clearGameState,
+  createInitialGameState,
+  deserializeGameState,
+  loadGameState,
+  saveGameState,
+  STORAGE_KEY,
+} from './game-storage'
+
+function createMockState(): PersistedGameState {
+  return {
+    schemaVersion: 1,
+    players: createDefaultPlayers(),
+    rounds: [],
+    settings: createDefaultSettings(),
+  }
+}
+
+describe('game storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('serializes and hydrates stored state', () => {
+    const state = createMockState()
+
+    saveGameState(localStorage, state)
+
+    expect(loadGameState(localStorage)).toEqual(state)
+  })
+
+  it('falls back to an initial state when the saved payload is invalid', () => {
+    localStorage.setItem(STORAGE_KEY, '{"schemaVersion":99}')
+
+    expect(loadGameState(localStorage)).toEqual(createInitialGameState())
+  })
+
+  it('returns null for malformed serialized input', () => {
+    expect(deserializeGameState('{not-json')).toBeNull()
+  })
+
+  it('can clear the saved game state', () => {
+    saveGameState(localStorage, createMockState())
+
+    clearGameState(localStorage)
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/storage/game-storage.ts
+++ b/src/storage/game-storage.ts
@@ -1,0 +1,64 @@
+import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
+import type { PersistedGameState } from '../domain/types'
+
+export const STORAGE_KEY = 'tichu-board-r1:v1'
+export const CURRENT_SCHEMA_VERSION = 1 as const
+
+export function createInitialGameState(): PersistedGameState {
+  return {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    players: createDefaultPlayers(),
+    rounds: [],
+    settings: createDefaultSettings(),
+  }
+}
+
+export function migratePersistedState(value: unknown): PersistedGameState | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  if (value.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    return null
+  }
+
+  if (!Array.isArray(value.players) || !Array.isArray(value.rounds) || !isRecord(value.settings)) {
+    return null
+  }
+
+  return value as PersistedGameState
+}
+
+export function deserializeGameState(value: string): PersistedGameState | null {
+  try {
+    return migratePersistedState(JSON.parse(value))
+  } catch {
+    return null
+  }
+}
+
+export function serializeGameState(state: PersistedGameState): string {
+  return JSON.stringify(state)
+}
+
+export function loadGameState(storage: Storage): PersistedGameState {
+  const savedValue = storage.getItem(STORAGE_KEY)
+
+  if (!savedValue) {
+    return createInitialGameState()
+  }
+
+  return deserializeGameState(savedValue) ?? createInitialGameState()
+}
+
+export function saveGameState(storage: Storage, state: PersistedGameState): void {
+  storage.setItem(STORAGE_KEY, serializeGameState(state))
+}
+
+export function clearGameState(storage: Storage): void {
+  storage.removeItem(STORAGE_KEY)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}


### PR DESCRIPTION
## Summary
- add the pure Tichu scoring engine, validation, cumulative score math, and game-end detection
- add default party/settings helpers and a versioned localStorage persistence layer
- cover scoring and storage behaviors with unit tests

## Checks
- pnpm lint
- pnpm test
- pnpm build