### PR TITLE
feat: build interactive score tracker ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@solid-primitives/i18n": "^2.2.1",
     "solid-js": "^1.9.10"
   },
   "devDependencies": {
@@ -28,10 +29,10 @@
     "jsdom": "^27.1.0",
     "tailwindcss": "^4.1.14",
     "typescript": "~5.9.3",
+    "typescript-eslint": "^8.46.3",
     "vite": "^7.3.1",
     "vite-plugin-solid": "^2.11.10",
-    "vitest": "^3.2.4",
-    "typescript-eslint": "^8.46.3"
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.27.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@solid-primitives/i18n':
+        specifier: ^2.2.1
+        version: 2.2.1(solid-js@1.9.11)
       solid-js:
         specifier: ^1.9.10
         version: 1.9.11
@@ -576,6 +579,11 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@solid-primitives/i18n@2.2.1':
+    resolution: {integrity: sha512-TnTnE2Ku11MGYZ1JzhJ8pYscwg1fr9MteoYxPwsfxWfh9Jp5K7RRJncJn9BhOHvNLwROjqOHZ46PT7sPHqbcXw==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@solidjs/testing-library@0.8.10':
     resolution: {integrity: sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ==}
@@ -2296,6 +2304,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@solid-primitives/i18n@2.2.1(solid-js@1.9.11)':
+    dependencies:
+      solid-js: 1.9.11
 
   '@solidjs/testing-library@0.8.10(solid-js@1.9.11)':
     dependencies:

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,12 +2,16 @@ import { render, screen } from '@solidjs/testing-library'
 import App from './App'
 
 describe('App', () => {
-  it('renders the project shell headline', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders the application heading', () => {
     render(() => <App />)
 
     expect(
       screen.getByRole('heading', {
-        name: /mobile-first tichu scorekeeping/i,
+        name: /fast tichu scoring for live table play/i,
       }),
     ).toBeInTheDocument()
   })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,47 +1,52 @@
-function App() {
+import { createSignal } from 'solid-js'
+import { PartySetup } from './features/party-setup/PartySetup'
+import { RoundEntry } from './features/rounds/RoundEntry'
+import { Scoreboard } from './features/scoreboard/Scoreboard'
+import { SettingsPanel } from './features/settings/SettingsPanel'
+import { GameProvider, useGame } from './state/game-context'
+
+function AppContent() {
+  const { t } = useGame()
+  const [editingRoundId, setEditingRoundId] = createSignal<string | null>(null)
+
   return (
     <main class="min-h-screen bg-[var(--color-bg)] text-[var(--color-fg)]">
-      <section class="mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center gap-6 px-5 py-12 sm:px-8">
-        <div class="inline-flex w-fit rounded-full border border-white/15 bg-white/8 px-3 py-1 text-xs uppercase tracking-[0.28em] text-[var(--color-accent)]">
-          Tichu Board R1
-        </div>
-        <div class="space-y-4">
-          <h1 class="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
-            Mobile-first Tichu scorekeeping with fast round entry and resilient local state
+      <section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+        <header class="rounded-[2.2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,191,105,0.16),rgba(255,255,255,0.04))] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.2)] backdrop-blur-sm motion-safe:animate-[fade-in_260ms_ease-out] sm:p-7">
+          <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
+            {t('app.badge')}
+          </div>
+          <h1 class="mt-4 max-w-3xl text-3xl font-semibold tracking-tight sm:text-5xl">
+            {t('app.title')}
           </h1>
-          <p class="max-w-2xl text-base leading-7 text-[var(--color-muted)] sm:text-lg">
-            The initial shell is ready. Next slices will add scoring, storage, bilingual UI, dark mode,
-            and round history on top of this baseline.
+          <p class="mt-3 max-w-2xl text-sm leading-7 text-[var(--color-muted)] sm:text-base">
+            {t('app.subtitle')}
           </p>
-        </div>
-        <div class="grid gap-3 sm:grid-cols-3">
-          <article class="rounded-3xl border border-white/12 bg-white/6 p-4 backdrop-blur-sm">
-            <h2 class="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--color-accent)]">
-              Domain
-            </h2>
-            <p class="mt-3 text-sm leading-6 text-[var(--color-muted)]">
-              Pure scoring rules and validation will land in the next branch.
-            </p>
-          </article>
-          <article class="rounded-3xl border border-white/12 bg-white/6 p-4 backdrop-blur-sm">
-            <h2 class="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--color-accent)]">
-              Interface
-            </h2>
-            <p class="mt-3 text-sm leading-6 text-[var(--color-muted)]">
-              The UI shell is set up for mobile-first layout, theme tokens, and animation-safe styling.
-            </p>
-          </article>
-          <article class="rounded-3xl border border-white/12 bg-white/6 p-4 backdrop-blur-sm">
-            <h2 class="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--color-accent)]">
-              Quality
-            </h2>
-            <p class="mt-3 text-sm leading-6 text-[var(--color-muted)]">
-              Lint, tests, and build will validate every feature branch before merge.
-            </p>
-          </article>
+        </header>
+
+        <div class="grid gap-4 xl:grid-cols-[1.12fr_0.88fr]">
+          <div class="grid gap-4">
+            <PartySetup />
+            <RoundEntry
+              editingRoundId={editingRoundId()}
+              onEditingRoundIdChange={setEditingRoundId}
+            />
+          </div>
+          <div class="grid gap-4">
+            <Scoreboard onEditRound={setEditingRoundId} />
+            <SettingsPanel />
+          </div>
         </div>
       </section>
     </main>
+  )
+}
+
+function App() {
+  return (
+    <GameProvider>
+      <AppContent />
+    </GameProvider>
   )
 }
 

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import App from '../../App'
+
+describe('PartySetup', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('updates player names and swaps seats with drag and drop', async () => {
+    render(() => <App />)
+
+    const northInput = screen.getByLabelText(/north player name/i)
+    await fireEvent.input(northInput, { target: { value: 'Alice' } })
+
+    expect((northInput as HTMLInputElement).value).toBe('Alice')
+
+    const northSeat = screen.getByTestId('seat-north')
+    const eastSeat = screen.getByTestId('seat-east')
+
+    await fireEvent.dragStart(northSeat)
+    await fireEvent.drop(eastSeat)
+
+    expect(within(screen.getByTestId('seat-east')).getByDisplayValue('Alice')).toBeInTheDocument()
+  })
+})

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -1,0 +1,81 @@
+import { For, createSignal } from 'solid-js'
+import { useGame } from '../../state/game-context'
+import type { PlayerId } from '../../domain/types'
+
+const seatOrder = ['north', 'east', 'south', 'west'] as const
+
+export function PartySetup() {
+  const { state, swapPlayerSeats, updatePlayerName, t } = useGame()
+  const [draggingPlayerId, setDraggingPlayerId] = createSignal<PlayerId | null>(null)
+
+  const playersBySeat = () =>
+    seatOrder
+      .map((seat) => state.players.find((player) => player.seat === seat))
+      .filter((player): player is NonNullable<typeof player> => Boolean(player))
+
+  return (
+    <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
+            {t('sections.party')}
+          </p>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-muted)]">{t('party.hint')}</p>
+        </div>
+      </div>
+      <div class="mt-5 grid gap-3 sm:grid-cols-2">
+        <For each={playersBySeat()}>
+          {(player) => {
+            const teamKey = player.seat === 'north' || player.seat === 'south' ? 'northSouth' : 'eastWest'
+
+            return (
+              <article
+                class="group rounded-[1.6rem] border border-white/10 bg-[var(--color-surface)] p-4 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5"
+                draggable="true"
+                onDragStart={() => setDraggingPlayerId(player.id)}
+                onDragEnd={() => setDraggingPlayerId(null)}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={() => {
+                  const sourceId = draggingPlayerId()
+
+                  if (!sourceId) {
+                    return
+                  }
+
+                  swapPlayerSeats(sourceId, player.id)
+                  setDraggingPlayerId(null)
+                }}
+                data-testid={`seat-${player.seat}`}
+              >
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <p class="text-xs uppercase tracking-[0.22em] text-[var(--color-accent)]">
+                      {t(`seats.${player.seat}`)}
+                    </p>
+                    <p class="mt-2 text-sm text-[var(--color-muted)]">
+                      {t('party.teamLabel', { team: t(`teams.${teamKey}`) })}
+                    </p>
+                  </div>
+                  <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-[var(--color-muted)]">
+                    {player.id}
+                  </span>
+                </div>
+                <label class="mt-4 block">
+                  <span class="sr-only">
+                    {t('party.nameLabel', { seat: t(`seats.${player.seat}`) })}
+                  </span>
+                  <input
+                    class="w-full rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-base text-[var(--color-fg)] outline-none transition-colors placeholder:text-[var(--color-muted)] focus:border-[var(--color-accent)]"
+                    value={player.name}
+                    onInput={(event) => updatePlayerName(player.id, event.currentTarget.value)}
+                    placeholder={t(`seats.${player.seat}`)}
+                  />
+                </label>
+              </article>
+            )
+          }}
+        </For>
+      </div>
+    </section>
+  )
+}

--- a/src/features/rounds/RoundEntry.test.tsx
+++ b/src/features/rounds/RoundEntry.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import App from '../../App'
+
+describe('RoundEntry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('saves a round and updates cumulative totals', async () => {
+    render(() => <App />)
+
+    const northSouthInput = screen.getByRole('spinbutton', {
+      name: /north \+ south/i,
+    })
+    const eastWestInput = screen.getByRole('spinbutton', {
+      name: /east \+ west/i,
+    })
+
+    await fireEvent.input(northSouthInput, { target: { value: '60' } })
+    await fireEvent.input(eastWestInput, { target: { value: '40' } })
+    await fireEvent.click(screen.getAllByRole('radio', { name: /first out/i })[0]!)
+    await fireEvent.click(screen.getByRole('button', { name: /save round/i }))
+
+    expect(screen.getByText(/round saved/i)).toBeInTheDocument()
+    expect(screen.getByText(/round history/i)).toBeInTheDocument()
+    expect(within(screen.getByTestId('team-total-north-south')).getByText('60')).toBeInTheDocument()
+    expect(within(screen.getByTestId('team-total-east-west')).getByText('40')).toBeInTheDocument()
+  })
+})

--- a/src/features/rounds/RoundEntry.tsx
+++ b/src/features/rounds/RoundEntry.tsx
@@ -1,0 +1,263 @@
+import { For, Show, createEffect, createMemo, createSignal } from 'solid-js'
+import { createStore, reconcile } from 'solid-js/store'
+import { createDefaultTichuCalls } from '../../domain/defaults'
+import { validateRoundInput } from '../../domain/scoring'
+import type { Player, RoundInput, TeamId, TichuCall } from '../../domain/types'
+import { useGame } from '../../state/game-context'
+
+type RoundEntryProps = {
+  editingRoundId: string | null
+  onEditingRoundIdChange: (roundId: string | null) => void
+}
+
+type RoundDraft = {
+  firstOutPlayerId: Player['id']
+  doubleVictoryTeamId: TeamId | ''
+  cardPointsNorthSouth: string
+  cardPointsEastWest: string
+  tichuCalls: Record<Player['id'], TichuCall>
+}
+
+export function RoundEntry(props: RoundEntryProps) {
+  const { state, addRound, findRound, t, updateRound } = useGame()
+  const [draft, setDraft] = createStore<RoundDraft>(createDraft(state.players))
+  const [errors, setErrors] = createSignal<string[]>([])
+  const [statusMessage, setStatusMessage] = createSignal('')
+  const editingRound = createMemo(() =>
+    props.editingRoundId ? findRound(props.editingRoundId) : undefined,
+  )
+  const editingRoundIndex = createMemo(() =>
+    props.editingRoundId ? state.rounds.findIndex((round) => round.id === props.editingRoundId) : -1,
+  )
+
+  createEffect(() => {
+    const currentRound = editingRound()
+
+    if (!currentRound) {
+      setDraft(replaceDraft(createDraft(state.players)))
+      setErrors([])
+      return
+    }
+
+    setDraft(replaceDraft(createDraftFromRound(currentRound.input)))
+    setErrors([])
+  })
+
+  createEffect(() => {
+    if (!state.players.some((player) => player.id === draft.firstOutPlayerId)) {
+      setDraft('firstOutPlayerId', state.players[0]?.id ?? 'player-1')
+    }
+  })
+
+  const submitLabel = () => (props.editingRoundId ? t('round.update') : t('round.save'))
+
+  return (
+    <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
+            {t('sections.round')}
+          </p>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-muted)]">{t('round.cardPointsHint')}</p>
+        </div>
+        <Show when={props.editingRoundId && editingRoundIndex() >= 0}>
+          <span class="rounded-full border border-amber-300/30 bg-amber-300/10 px-3 py-1 text-xs text-amber-100">
+            {t('round.editing', { round: editingRoundIndex() + 1 })}
+          </span>
+        </Show>
+      </div>
+
+      <form
+        class="mt-5 space-y-5"
+        onSubmit={(event) => {
+          event.preventDefault()
+
+          const input = buildRoundInput(draft)
+          const validation = validateRoundInput(state.players, input)
+
+          if (!validation.ok) {
+            setErrors(validation.errors.map((error) => error.message))
+            setStatusMessage('')
+            return
+          }
+
+          if (props.editingRoundId) {
+            updateRound(props.editingRoundId, input)
+            props.onEditingRoundIdChange(null)
+            setStatusMessage(t('actions.updateSuccess'))
+          } else {
+            addRound(input)
+            setStatusMessage(t('actions.saveSuccess'))
+          }
+
+          setDraft(replaceDraft(createDraft(state.players)))
+          setErrors([])
+        }}
+      >
+        <div class="grid gap-3">
+          <For each={state.players}>
+            {(player) => (
+              <article class="rounded-[1.5rem] border border-white/10 bg-[var(--color-surface)] p-4">
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <p class="text-sm font-semibold text-[var(--color-fg)]">{player.name}</p>
+                    <p class="text-xs uppercase tracking-[0.2em] text-[var(--color-muted)]">
+                      {t(`seats.${player.seat}`)}
+                    </p>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <label class="text-xs text-[var(--color-muted)]" for={`call-${player.id}`}>
+                      {t('round.tichu')}
+                    </label>
+                    <select
+                      id={`call-${player.id}`}
+                      class="rounded-full border border-white/10 bg-black/15 px-3 py-2 text-sm text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
+                      value={draft.tichuCalls[player.id]}
+                      onInput={(event) =>
+                        setDraft('tichuCalls', player.id, event.currentTarget.value as TichuCall)
+                      }
+                    >
+                      <option value="none">{t('round.noCall')}</option>
+                      <option value="small">{t('round.small')}</option>
+                      <option value="grand">{t('round.grand')}</option>
+                    </select>
+                  </div>
+                </div>
+                <label class="mt-4 flex items-center gap-3 rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-[var(--color-fg)]">
+                  <input
+                    type="radio"
+                    name="first-out-player"
+                    checked={draft.firstOutPlayerId === player.id}
+                    onChange={() => setDraft('firstOutPlayerId', player.id)}
+                  />
+                  <span>{t('round.firstOut')}</span>
+                </label>
+              </article>
+            )}
+          </For>
+        </div>
+
+        <div class="grid gap-4 rounded-[1.5rem] border border-white/10 bg-[var(--color-surface)] p-4 sm:grid-cols-3">
+          <label class="grid gap-2 text-sm">
+            <span class="text-[var(--color-muted)]">{t('round.doubleVictory')}</span>
+            <select
+              class="rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
+              value={draft.doubleVictoryTeamId}
+              onInput={(event) =>
+                setDraft('doubleVictoryTeamId', event.currentTarget.value as TeamId | '')
+              }
+            >
+              <option value="">{t('round.noDoubleVictory')}</option>
+              <option value="north-south">{t('teams.northSouth')}</option>
+              <option value="east-west">{t('teams.eastWest')}</option>
+            </select>
+          </label>
+
+          <label class="grid gap-2 text-sm">
+            <span class="text-[var(--color-muted)]">{t('teams.northSouth')}</span>
+            <input
+              inputMode="numeric"
+              type="number"
+              min="0"
+              max="100"
+              disabled={Boolean(draft.doubleVictoryTeamId)}
+              class="rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-[var(--color-fg)] outline-none transition-opacity focus:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-40"
+              value={draft.cardPointsNorthSouth}
+              onInput={(event) => setDraft('cardPointsNorthSouth', event.currentTarget.value)}
+            />
+          </label>
+
+          <label class="grid gap-2 text-sm">
+            <span class="text-[var(--color-muted)]">{t('teams.eastWest')}</span>
+            <input
+              inputMode="numeric"
+              type="number"
+              min="0"
+              max="100"
+              disabled={Boolean(draft.doubleVictoryTeamId)}
+              class="rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-[var(--color-fg)] outline-none transition-opacity focus:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-40"
+              value={draft.cardPointsEastWest}
+              onInput={(event) => setDraft('cardPointsEastWest', event.currentTarget.value)}
+            />
+          </label>
+        </div>
+
+        <Show when={errors().length > 0}>
+          <div class="rounded-[1.25rem] border border-rose-400/30 bg-rose-400/10 px-4 py-3 text-sm text-rose-100">
+            <ul class="space-y-1">
+              <For each={errors()}>{(error) => <li>{error}</li>}</For>
+            </ul>
+          </div>
+        </Show>
+
+        <Show when={statusMessage()}>
+          <div class="rounded-[1.25rem] border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-50">
+            {statusMessage()}
+          </div>
+        </Show>
+
+        <div class="sticky bottom-3 z-10 flex gap-3 rounded-[1.5rem] border border-white/10 bg-[color:color-mix(in_srgb,var(--color-bg)_78%,transparent)] p-3 backdrop-blur">
+          <button
+            type="submit"
+            class="flex-1 rounded-2xl bg-[var(--color-accent)] px-4 py-3 text-sm font-semibold text-slate-950 transition-transform duration-150 motion-safe:hover:-translate-y-0.5"
+          >
+            {submitLabel()}
+          </button>
+          <Show when={props.editingRoundId}>
+            <button
+              type="button"
+              class="rounded-2xl border border-white/12 px-4 py-3 text-sm text-[var(--color-fg)]"
+              onClick={() => {
+                props.onEditingRoundIdChange(null)
+                setDraft(replaceDraft(createDraft(state.players)))
+                setErrors([])
+              }}
+            >
+              {t('round.cancel')}
+            </button>
+          </Show>
+        </div>
+      </form>
+    </section>
+  )
+}
+
+function createDraft(players: Player[]): RoundDraft {
+  return {
+    firstOutPlayerId: players[0]?.id ?? 'player-1',
+    doubleVictoryTeamId: '',
+    cardPointsNorthSouth: '50',
+    cardPointsEastWest: '50',
+    tichuCalls: createDefaultTichuCalls(),
+  }
+}
+
+function createDraftFromRound(input: RoundInput): RoundDraft {
+  return {
+    firstOutPlayerId: input.firstOutPlayerId,
+    doubleVictoryTeamId: input.doubleVictoryTeamId ?? '',
+    cardPointsNorthSouth: input.cardPoints ? String(input.cardPoints['north-south']) : '50',
+    cardPointsEastWest: input.cardPoints ? String(input.cardPoints['east-west']) : '50',
+    tichuCalls: { ...input.tichuCalls },
+  }
+}
+
+function replaceDraft(draft: RoundDraft) {
+  return reconcile(draft)
+}
+
+function buildRoundInput(draft: RoundDraft): RoundInput {
+  const doubleVictoryTeamId = draft.doubleVictoryTeamId || null
+
+  return {
+    firstOutPlayerId: draft.firstOutPlayerId,
+    doubleVictoryTeamId,
+    tichuCalls: { ...draft.tichuCalls },
+    cardPoints: doubleVictoryTeamId
+      ? null
+      : {
+          'north-south': Number(draft.cardPointsNorthSouth || 0),
+          'east-west': Number(draft.cardPointsEastWest || 0),
+        },
+  }
+}

--- a/src/features/scoreboard/Scoreboard.tsx
+++ b/src/features/scoreboard/Scoreboard.tsx
@@ -1,0 +1,179 @@
+import { For, Show } from 'solid-js'
+import { useGame } from '../../state/game-context'
+import type { TeamId } from '../../domain/types'
+
+type ScoreboardProps = {
+  onEditRound: (roundId: string) => void
+}
+
+export function Scoreboard(props: ScoreboardProps) {
+  const {
+    cumulativeScores,
+    deleteRound,
+    duplicateRound,
+    gameStatus,
+    leadingTeamId,
+    state,
+    t,
+    teamNames,
+  } = useGame()
+
+  return (
+    <section class="space-y-4">
+      <Show when={gameStatus().tieBreakRequired}>
+        <Banner tone="amber">{t('banners.tieBreak')}</Banner>
+      </Show>
+      <Show when={gameStatus().isGameOver && gameStatus().winnerTeamId}>
+        <Banner tone="emerald">
+          {t('banners.winner', {
+            team: teamNames()[gameStatus().winnerTeamId as TeamId],
+          })}
+        </Banner>
+      </Show>
+
+      <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+        <div class="flex items-center justify-between">
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
+            {t('sections.scoreboard')}
+          </p>
+          <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-[var(--color-muted)]">
+            {state.rounds.length} {t('scoreboard.rounds')}
+          </span>
+        </div>
+
+        <div class="mt-5 grid gap-3">
+          <TeamTotalCard
+            teamId="north-south"
+            total={cumulativeScores()['north-south']}
+            label={teamNames()['north-south']}
+            isLeading={leadingTeamId() === 'north-south'}
+          />
+          <TeamTotalCard
+            teamId="east-west"
+            total={cumulativeScores()['east-west']}
+            label={teamNames()['east-west']}
+            isLeading={leadingTeamId() === 'east-west'}
+          />
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
+            {t('scoreboard.history')}
+          </p>
+        </div>
+
+        <Show
+          when={state.rounds.length > 0}
+          fallback={
+            <p class="mt-4 rounded-[1.5rem] border border-dashed border-white/12 px-4 py-6 text-sm text-[var(--color-muted)]">
+              {t('scoreboard.empty')}
+            </p>
+          }
+        >
+          <div class="mt-4 space-y-3">
+            <For each={state.rounds}>
+              {(round, index) => (
+                <article class="rounded-[1.5rem] border border-white/10 bg-[var(--color-surface)] p-4 motion-safe:animate-[slide-up_220ms_ease-out]">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 class="text-base font-semibold text-[var(--color-fg)]">
+                        {t('scoreboard.roundLabel', { round: index() + 1 })}
+                      </h3>
+                      <p class="mt-1 text-sm text-[var(--color-muted)]">
+                        {t('scoreboard.cardPoints')}: {round.result.cardPoints['north-south']} /{' '}
+                        {round.result.cardPoints['east-west']}
+                      </p>
+                      <p class="text-sm text-[var(--color-muted)]">
+                        {t('scoreboard.bonuses')}: {round.result.tichuBonuses['north-south']} /{' '}
+                        {round.result.tichuBonuses['east-west']}
+                      </p>
+                    </div>
+                    <div class="grid gap-2 text-right">
+                      <span class="text-lg font-semibold text-[var(--color-fg)]">
+                        {round.result.roundTotals['north-south']} : {round.result.roundTotals['east-west']}
+                      </span>
+                      <div class="flex justify-end gap-2">
+                        <ActionButton onClick={() => props.onEditRound(round.id)}>
+                          {t('scoreboard.edit')}
+                        </ActionButton>
+                        <ActionButton onClick={() => duplicateRound(round.id)}>
+                          {t('scoreboard.duplicate')}
+                        </ActionButton>
+                        <ActionButton onClick={() => deleteRound(round.id)}>
+                          {t('scoreboard.delete')}
+                        </ActionButton>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              )}
+            </For>
+          </div>
+        </Show>
+      </section>
+    </section>
+  )
+}
+
+function TeamTotalCard(props: {
+  teamId: TeamId
+  total: number
+  label: string
+  isLeading: boolean
+}) {
+  const { t } = useGame()
+
+  return (
+    <article
+      class={`rounded-[1.6rem] border p-4 transition-transform duration-200 motion-safe:hover:-translate-y-0.5 ${
+        props.isLeading
+          ? 'border-amber-300/40 bg-amber-300/10'
+          : 'border-white/10 bg-[var(--color-surface)]'
+      }`}
+      data-testid={`team-total-${props.teamId}`}
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <p class="text-xs uppercase tracking-[0.22em] text-[var(--color-accent)]">{props.label}</p>
+          <Show when={props.isLeading}>
+            <p class="mt-2 text-sm text-amber-100">{t('scoreboard.leading')}</p>
+          </Show>
+        </div>
+        <div class="text-right">
+          <p class="text-xs uppercase tracking-[0.22em] text-[var(--color-muted)]">
+            {t('scoreboard.total')}
+          </p>
+          <p class="mt-2 text-3xl font-semibold text-[var(--color-fg)]">{props.total}</p>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function Banner(props: { children: string; tone: 'amber' | 'emerald' }) {
+  return (
+    <div
+      class={`rounded-[1.5rem] border px-4 py-3 text-sm ${
+        props.tone === 'amber'
+          ? 'border-amber-300/35 bg-amber-300/10 text-amber-50'
+          : 'border-emerald-300/35 bg-emerald-300/10 text-emerald-50'
+      }`}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+function ActionButton(props: { children: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      class="rounded-full border border-white/10 px-3 py-2 text-xs text-[var(--color-fg)]"
+      onClick={() => props.onClick()}
+    >
+      {props.children}
+    </button>
+  )
+}

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import App from '../../App'
+
+describe('SettingsPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.dataset.theme = 'dark'
+  })
+
+  it('switches language to Korean', async () => {
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /korean/i }))
+
+    expect(
+      screen.getByRole('heading', { name: /실전 플레이를 위한 빠른 티츄 점수 계산기/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('applies the selected theme to the document root', async () => {
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /light/i }))
+
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+})

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,0 +1,84 @@
+import { For } from 'solid-js'
+import type { ThemeMode } from '../../domain/types'
+import { useGame } from '../../state/game-context'
+
+const themeModes: ThemeMode[] = ['system', 'light', 'dark']
+
+export function SettingsPanel() {
+  const { resetGame, setLanguage, setTheme, state, t } = useGame()
+
+  return (
+    <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+      <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
+        {t('sections.settings')}
+      </p>
+
+      <div class="mt-5 grid gap-4">
+        <div class="grid gap-2">
+          <span class="text-sm text-[var(--color-muted)]">{t('settings.language')}</span>
+          <div class="flex gap-2">
+            <LanguageButton
+              isActive={state.settings.language === 'en'}
+              onClick={() => setLanguage('en')}
+              label={t('language.english')}
+            />
+            <LanguageButton
+              isActive={state.settings.language === 'ko'}
+              onClick={() => setLanguage('ko')}
+              label={t('language.korean')}
+            />
+          </div>
+        </div>
+
+        <div class="grid gap-2">
+          <span class="text-sm text-[var(--color-muted)]">{t('settings.theme')}</span>
+          <div class="grid grid-cols-3 gap-2">
+            <For each={themeModes}>
+              {(mode) => (
+                <button
+                  type="button"
+                  class={`rounded-2xl px-4 py-3 text-sm transition-colors ${
+                    state.settings.theme === mode
+                      ? 'bg-[var(--color-accent)] text-slate-950'
+                      : 'border border-white/10 bg-black/15 text-[var(--color-fg)]'
+                  }`}
+                  onClick={() => setTheme(mode)}
+                >
+                  {t(`settings.${mode}`)}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="rounded-2xl border border-rose-300/35 bg-rose-300/10 px-4 py-3 text-sm text-rose-50"
+          onClick={() => {
+            if (window.confirm(t('settings.resetConfirm'))) {
+              resetGame()
+            }
+          }}
+        >
+          {t('settings.reset')}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function LanguageButton(props: { isActive: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      class={`rounded-2xl px-4 py-3 text-sm transition-colors ${
+        props.isActive
+          ? 'bg-[var(--color-accent)] text-slate-950'
+          : 'border border-white/10 bg-black/15 text-[var(--color-fg)]'
+      }`}
+      onClick={() => props.onClick()}
+    >
+      {props.label}
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,17 +2,34 @@
 @import 'tailwindcss';
 
 :root {
-  color-scheme: dark;
-  --color-bg: #08111f;
-  --color-fg: #f5f1e8;
-  --color-muted: #c7c2b8;
+  --color-bg: #0b1323;
+  --color-surface: rgba(255, 255, 255, 0.08);
+  --color-fg: #f5efe5;
+  --color-muted: #c5c0b5;
   --color-accent: #ffbf69;
-  --color-panel: rgba(255, 255, 255, 0.08);
   font-family: 'Space Grotesk', sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --color-bg: #f5efe4;
+  --color-surface: rgba(255, 255, 255, 0.7);
+  --color-fg: #10203a;
+  --color-muted: #526077;
+  --color-accent: #ca6d1a;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --color-bg: #0b1323;
+  --color-surface: rgba(255, 255, 255, 0.08);
+  --color-fg: #f5efe5;
+  --color-muted: #c5c0b5;
+  --color-accent: #ffbf69;
 }
 
 * {
@@ -22,8 +39,8 @@
 html {
   min-width: 320px;
   background:
-    radial-gradient(circle at top, rgba(255, 191, 105, 0.22), transparent 28%),
-    linear-gradient(180deg, #10223d 0%, #08111f 55%, #050a12 100%);
+    radial-gradient(circle at top, rgba(255, 191, 105, 0.2), transparent 30%),
+    linear-gradient(180deg, color-mix(in srgb, var(--color-bg) 92%, white) 0%, var(--color-bg) 100%);
   background-color: var(--color-bg);
 }
 
@@ -31,6 +48,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background: transparent;
 }
 
 button,
@@ -40,6 +58,45 @@ textarea {
   font: inherit;
 }
 
+button {
+  cursor: pointer;
+}
+
 #root {
   min-height: 100vh;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1,0 +1,174 @@
+import { flatten, resolveTemplate, translator } from '@solid-primitives/i18n'
+import type { Language } from '../domain/types'
+
+const dictionaries = {
+  en: flatten({
+    app: {
+      badge: 'Tichu Board R1',
+      title: 'Fast Tichu scoring for live table play',
+      subtitle:
+        'Set the party, enter rounds quickly, and keep cumulative scores stable across reloads.',
+    },
+    sections: {
+      party: 'Party Setup',
+      round: 'Round Entry',
+      scoreboard: 'Scoreboard',
+      settings: 'Settings',
+    },
+    seats: {
+      north: 'North',
+      east: 'East',
+      south: 'South',
+      west: 'West',
+    },
+    teams: {
+      northSouth: 'North + South',
+      eastWest: 'East + West',
+    },
+    party: {
+      hint: 'Drag player cards onto another seat to swap positions.',
+      nameLabel: '{{ seat }} player name',
+      teamLabel: 'Team {{ team }}',
+    },
+    round: {
+      firstOut: 'First Out',
+      doubleVictory: 'Double Victory',
+      noDoubleVictory: 'None',
+      teamPoints: 'Team Card Points',
+      tichu: 'Tichu',
+      save: 'Save Round',
+      update: 'Update Round',
+      cancel: 'Cancel Edit',
+      noCall: 'No Call',
+      small: 'Small',
+      grand: 'Grand',
+      cardPointsHint: 'Normal rounds must total 100 points across both teams.',
+      editing: 'Editing round {{ round }}',
+    },
+    scoreboard: {
+      total: 'Total',
+      rounds: 'Rounds',
+      empty: 'No rounds yet. Enter the first round to start the scoreboard.',
+      history: 'Round History',
+      roundLabel: 'Round {{ round }}',
+      edit: 'Edit',
+      delete: 'Delete',
+      duplicate: 'Duplicate',
+      cardPoints: 'Card points',
+      bonuses: 'Tichu bonuses',
+      leading: 'Leading',
+    },
+    settings: {
+      language: 'Language',
+      theme: 'Theme',
+      system: 'System',
+      light: 'Light',
+      dark: 'Dark',
+      reset: 'Reset Game',
+      resetConfirm: 'Reset the saved game state?',
+    },
+    banners: {
+      winner: '{{ team }} wins the game.',
+      tieBreak: 'Both teams crossed 1000 with the same score. Play one more round.',
+    },
+    actions: {
+      saveSuccess: 'Round saved.',
+      updateSuccess: 'Round updated.',
+    },
+    language: {
+      english: 'English',
+      korean: 'Korean',
+    },
+  }),
+  ko: flatten({
+    app: {
+      badge: 'Tichu Board R1',
+      title: '실전 플레이를 위한 빠른 티츄 점수 계산기',
+      subtitle:
+        '플레이어를 배치하고, 라운드를 빠르게 입력하고, 새로고침 후에도 누적 점수를 안정적으로 유지합니다.',
+    },
+    sections: {
+      party: '플레이어 설정',
+      round: '라운드 입력',
+      scoreboard: '점수판',
+      settings: '설정',
+    },
+    seats: {
+      north: '북',
+      east: '동',
+      south: '남',
+      west: '서',
+    },
+    teams: {
+      northSouth: '북 + 남',
+      eastWest: '동 + 서',
+    },
+    party: {
+      hint: '플레이어 카드를 다른 자리로 드래그하면 자리가 서로 바뀝니다.',
+      nameLabel: '{{ seat }} 플레이어 이름',
+      teamLabel: '{{ team }} 팀',
+    },
+    round: {
+      firstOut: '첫 아웃',
+      doubleVictory: '더블 빅토리',
+      noDoubleVictory: '없음',
+      teamPoints: '팀 카드 점수',
+      tichu: '티츄',
+      save: '라운드 저장',
+      update: '라운드 수정',
+      cancel: '수정 취소',
+      noCall: '콜 없음',
+      small: '스몰',
+      grand: '그랜드',
+      cardPointsHint: '일반 라운드에서는 양 팀 카드 점수 합이 100이어야 합니다.',
+      editing: '{{ round }}라운드 수정 중',
+    },
+    scoreboard: {
+      total: '총점',
+      rounds: '라운드',
+      empty: '아직 라운드가 없습니다. 첫 라운드를 입력해 주세요.',
+      history: '라운드 기록',
+      roundLabel: '{{ round }}라운드',
+      edit: '수정',
+      delete: '삭제',
+      duplicate: '복제',
+      cardPoints: '카드 점수',
+      bonuses: '티츄 보너스',
+      leading: '선두',
+    },
+    settings: {
+      language: '언어',
+      theme: '테마',
+      system: '시스템',
+      light: '라이트',
+      dark: '다크',
+      reset: '게임 초기화',
+      resetConfirm: '저장된 게임 상태를 초기화할까요?',
+    },
+    banners: {
+      winner: '{{ team }} 팀이 승리했습니다.',
+      tieBreak: '양 팀이 같은 점수로 1000점을 넘었습니다. 한 라운드를 더 진행하세요.',
+    },
+    actions: {
+      saveSuccess: '라운드가 저장되었습니다.',
+      updateSuccess: '라운드가 수정되었습니다.',
+    },
+    language: {
+      english: '영어',
+      korean: '한국어',
+    },
+  }),
+} as const
+
+type Dictionary = (typeof dictionaries)['en']
+export type TranslationKey = keyof Dictionary
+
+export function createTranslator(language: Language) {
+  const currentDictionary = dictionaries[language]
+  const translate = translator(() => currentDictionary, resolveTemplate)
+
+  return (key: TranslationKey, args?: Record<string, string | number | boolean>) => {
+    const value = args ? translate(key, args) : translate(key)
+    return typeof value === 'string' ? value : ''
+  }
+}

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -1,0 +1,238 @@
+import {
+  createContext,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  useContext,
+  type ParentComponent,
+} from 'solid-js'
+import { createStore, reconcile, unwrap } from 'solid-js/store'
+import { createTranslator, type TranslationKey } from '../shared/i18n'
+import { getTeamIdBySeat } from '../domain/helpers'
+import {
+  calculateCumulativeScores,
+  calculateRoundScore,
+  getGameStatus,
+  getLeadingTeamId,
+} from '../domain/scoring'
+import type {
+  PersistedGameState,
+  Player,
+  PlayerId,
+  RoundInput,
+  RoundRecord,
+  TeamId,
+  ThemeMode,
+} from '../domain/types'
+import {
+  clearGameState,
+  createInitialGameState,
+  loadGameState,
+  saveGameState,
+} from '../storage/game-storage'
+
+type GameContextValue = {
+  state: PersistedGameState
+  cumulativeScores: () => ReturnType<typeof calculateCumulativeScores>
+  gameStatus: () => ReturnType<typeof getGameStatus>
+  leadingTeamId: () => ReturnType<typeof getLeadingTeamId>
+  teamNames: () => Record<TeamId, string>
+  systemTheme: () => Exclude<ThemeMode, 'system'>
+  effectiveTheme: () => Exclude<ThemeMode, 'system'>
+  t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
+  updatePlayerName: (playerId: PlayerId, name: string) => void
+  swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
+  setLanguage: (language: PersistedGameState['settings']['language']) => void
+  setTheme: (theme: ThemeMode) => void
+  addRound: (input: RoundInput) => void
+  updateRound: (roundId: string, input: RoundInput) => void
+  deleteRound: (roundId: string) => void
+  duplicateRound: (roundId: string) => void
+  findRound: (roundId: string) => RoundRecord | undefined
+  resetGame: () => void
+}
+
+const GameContext = createContext<GameContextValue>()
+
+export const GameProvider: ParentComponent = (props) => {
+  const [systemTheme, setSystemTheme] = createSignal<Exclude<ThemeMode, 'system'>>(detectSystemTheme())
+  const [state, setState] = createStore<PersistedGameState>(loadInitialState())
+
+  const translate = createMemo(() => createTranslator(state.settings.language))
+  const cumulativeScores = createMemo(() =>
+    calculateCumulativeScores(state.rounds.map((round) => round.result)),
+  )
+  const gameStatus = createMemo(() => getGameStatus(cumulativeScores()))
+  const leadingTeamId = createMemo(() => getLeadingTeamId(cumulativeScores()))
+  const teamNames = createMemo(() => {
+    const names = {
+      'north-south': [] as string[],
+      'east-west': [] as string[],
+    }
+
+    for (const player of state.players) {
+      names[getTeamIdBySeat(player.seat)].push(player.name)
+    }
+
+    return {
+      'north-south': names['north-south'].join(' / '),
+      'east-west': names['east-west'].join(' / '),
+    }
+  })
+  const effectiveTheme = createMemo<Exclude<ThemeMode, 'system'>>(() =>
+    state.settings.theme === 'system' ? systemTheme() : state.settings.theme,
+  )
+
+  const mediaQuery =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : null
+
+  if (mediaQuery) {
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? 'dark' : 'light')
+    }
+
+    setSystemTheme(mediaQuery.matches ? 'dark' : 'light')
+    mediaQuery.addEventListener('change', handleChange)
+    onCleanup(() => mediaQuery.removeEventListener('change', handleChange))
+  }
+
+  createEffect(() => {
+    saveGameState(window.localStorage, unwrap(state))
+  })
+
+  createEffect(() => {
+    document.documentElement.dataset.theme = effectiveTheme()
+    document.documentElement.lang = state.settings.language
+  })
+
+  const value: GameContextValue = {
+    state,
+    cumulativeScores,
+    gameStatus,
+    leadingTeamId,
+    teamNames,
+    systemTheme,
+    effectiveTheme,
+    t: (key, args) => translate()(key, args),
+    updatePlayerName: (playerId, name) => {
+      const trimmedName = name.trimStart().slice(0, 24)
+
+      setState(
+        'players',
+        (player) => player.id === playerId,
+        'name',
+        (currentName) => trimmedName || currentName,
+      )
+    },
+    swapPlayerSeats: (sourcePlayerId, targetPlayerId) => {
+      if (sourcePlayerId === targetPlayerId) {
+        return
+      }
+
+      const sourcePlayer = state.players.find((player) => player.id === sourcePlayerId)
+      const targetPlayer = state.players.find((player) => player.id === targetPlayerId)
+
+      if (!sourcePlayer || !targetPlayer) {
+        return
+      }
+
+      setState(
+        'players',
+        state.players.map((player) => {
+          if (player.id === sourcePlayerId) {
+            return { ...player, seat: targetPlayer.seat }
+          }
+
+          if (player.id === targetPlayerId) {
+            return { ...player, seat: sourcePlayer.seat }
+          }
+
+          return player
+        }),
+      )
+    },
+    setLanguage: (language) => setState('settings', 'language', language),
+    setTheme: (theme) => setState('settings', 'theme', theme),
+    addRound: (input) => {
+      const round = createRoundRecord(state.players, input)
+      setState('rounds', (rounds) => [...rounds, round])
+    },
+    updateRound: (roundId, input) => {
+      const round = createRoundRecord(state.players, input, roundId)
+      setState(
+        'rounds',
+        state.rounds.map((item) => (item.id === roundId ? round : item)),
+      )
+    },
+    deleteRound: (roundId) => {
+      setState(
+        'rounds',
+        state.rounds.filter((round) => round.id !== roundId),
+      )
+    },
+    duplicateRound: (roundId) => {
+      const round = state.rounds.find((item) => item.id === roundId)
+
+      if (!round) {
+        return
+      }
+
+      setState('rounds', (rounds) => [
+        ...rounds,
+        createRoundRecord(state.players, round.input),
+      ])
+    },
+    findRound: (roundId) => state.rounds.find((round) => round.id === roundId),
+    resetGame: () => {
+      clearGameState(window.localStorage)
+      setState(reconcile(createInitialGameState()))
+    },
+  }
+
+  return <GameContext.Provider value={value}>{props.children}</GameContext.Provider>
+}
+
+export function useGame() {
+  const context = useContext(GameContext)
+
+  if (!context) {
+    throw new Error('useGame must be used within GameProvider')
+  }
+
+  return context
+}
+
+function loadInitialState() {
+  if (typeof window === 'undefined') {
+    return createInitialGameState()
+  }
+
+  return loadGameState(window.localStorage)
+}
+
+function detectSystemTheme(): Exclude<ThemeMode, 'system'> {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'dark'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function createRoundRecord(players: Player[], input: RoundInput, roundId = createRoundId()): RoundRecord {
+  return {
+    id: roundId,
+    input,
+    result: calculateRoundScore(players, input),
+  }
+}
+
+function createRoundId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `round-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}


### PR DESCRIPTION
## Summary
- add the initial interactive Tichu score tracker UI with party setup, round entry, scoreboard, and settings
- wire the UI to the scoring engine and localStorage-backed game context
- add component tests for party setup, round flow, language switching, and theme switching

## Checks
- pnpm lint
- pnpm test
- pnpm build