### PR TITLE
feat: rebrand app as TichuBoard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/tichu-board-r1/favicon.svg" />
     <meta
       name="description"
-      content="Mobile-first Tichu score calculator with local persistence, bilingual support, and round history."
+      content="TichuBoard is a mobile-first Tichu score tracker with local persistence, bilingual support, and fast round entry."
     />
-    <title>Tichu Board R1</title>
+    <meta name="theme-color" content="#0b1323" />
+    <meta property="og:title" content="TichuBoard" />
+    <meta
+      property="og:description"
+      content="A mobile-first Tichu score tracker built for real gameplay at the table."
+    />
+    <meta property="og:type" content="website" />
+    <title>TichuBoard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="80" height="80" rx="24" fill="#0F1A2F"/>
+  <rect x="14" y="14" width="68" height="68" rx="20" fill="#FFBF69" fill-opacity="0.18"/>
+  <path d="M31 28H65C69.4183 28 73 31.5817 73 36V41C73 45.4183 69.4183 49 65 49H51V68H42V49H31C26.5817 49 23 45.4183 23 41V36C23 31.5817 26.5817 28 31 28Z" fill="#FF9A5A"/>
+  <path d="M36 34H60C62.7614 34 65 36.2386 65 39C65 41.7614 62.7614 44 60 44H36C33.2386 44 31 41.7614 31 39C31 36.2386 33.2386 34 36 34Z" fill="#F8F2E8"/>
+  <circle cx="48" cy="62" r="6" fill="#F8F2E8"/>
+</svg>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,7 +11,7 @@ describe('App', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: /fast tichu scoring for live table play/i,
+        name: /tichuboard/i,
       }),
     ).toBeInTheDocument()
   })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { PartySetup } from './features/party-setup/PartySetup'
 import { RoundEntry } from './features/rounds/RoundEntry'
 import { Scoreboard } from './features/scoreboard/Scoreboard'
 import { SettingsPanel } from './features/settings/SettingsPanel'
+import { BrandLogo } from './shared/BrandLogo'
 import { GameProvider, useGame } from './state/game-context'
 
 function AppContent() {
@@ -13,10 +14,15 @@ function AppContent() {
     <main class="min-h-screen bg-[var(--color-bg)] text-[var(--color-fg)]">
       <section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
         <header class="rounded-[2.2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,191,105,0.16),rgba(255,255,255,0.04))] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.2)] backdrop-blur-sm motion-safe:animate-[fade-in_260ms_ease-out] sm:p-7">
-          <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
-            {t('app.badge')}
+          <div class="flex items-center gap-3">
+            <div class="flex h-14 w-14 items-center justify-center rounded-[1.2rem] border border-white/12 bg-slate-950/35 shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+              <BrandLogo class="h-10 w-10" />
+            </div>
+            <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
+              {t('app.badge')}
+            </div>
           </div>
-          <h1 class="mt-4 max-w-3xl text-3xl font-semibold tracking-tight sm:text-5xl">
+          <h1 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">
             {t('app.title')}
           </h1>
           <p class="mt-3 max-w-2xl text-sm leading-7 text-[var(--color-muted)] sm:text-base">

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -12,8 +12,9 @@ describe('SettingsPanel', () => {
 
     await fireEvent.click(screen.getByRole('button', { name: /korean/i }))
 
+    expect(screen.getByRole('heading', { name: /tichuboard/i })).toBeInTheDocument()
     expect(
-      screen.getByRole('heading', { name: /실전 플레이를 위한 빠른 티츄 점수 계산기/i }),
+      screen.getByText(/실전 플레이를 위한 모바일 중심 티츄 점수 동반 앱으로, 로컬 기록을 안정적으로 유지합니다/i),
     ).toBeInTheDocument()
   })
 

--- a/src/shared/BrandLogo.tsx
+++ b/src/shared/BrandLogo.tsx
@@ -1,0 +1,33 @@
+type BrandLogoProps = {
+  class?: string
+}
+
+export function BrandLogo(props: BrandLogoProps) {
+  return (
+    <svg
+      viewBox="0 0 96 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      class={props.class}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id="board-glow" x1="18" y1="16" x2="82" y2="84" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#FFBF69" />
+          <stop offset="1" stop-color="#FF7A59" />
+        </linearGradient>
+      </defs>
+      <rect x="8" y="8" width="80" height="80" rx="24" fill="#0F1A2F" />
+      <rect x="14" y="14" width="68" height="68" rx="20" fill="url(#board-glow)" fill-opacity="0.18" />
+      <path
+        d="M31 28H65C69.4183 28 73 31.5817 73 36V41C73 45.4183 69.4183 49 65 49H51V68H42V49H31C26.5817 49 23 45.4183 23 41V36C23 31.5817 26.5817 28 31 28Z"
+        fill="url(#board-glow)"
+      />
+      <path
+        d="M36 34H60C62.7614 34 65 36.2386 65 39V39C65 41.7614 62.7614 44 60 44H36C33.2386 44 31 41.7614 31 39V39C31 36.2386 33.2386 34 36 34Z"
+        fill="#F8F2E8"
+      />
+      <circle cx="48" cy="62" r="6" fill="#F8F2E8" />
+    </svg>
+  )
+}

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -4,10 +4,10 @@ import type { Language } from '../domain/types'
 const dictionaries = {
   en: flatten({
     app: {
-      badge: 'Tichu Board R1',
-      title: 'Fast Tichu scoring for live table play',
+      badge: 'Tichu score tracker',
+      title: 'TichuBoard',
       subtitle:
-        'Set the party, enter rounds quickly, and keep cumulative scores stable across reloads.',
+        'A fast, mobile-first score companion for live Tichu sessions with resilient local history.',
     },
     sections: {
       party: 'Party Setup',
@@ -82,10 +82,10 @@ const dictionaries = {
   }),
   ko: flatten({
     app: {
-      badge: 'Tichu Board R1',
-      title: '실전 플레이를 위한 빠른 티츄 점수 계산기',
+      badge: '티츄 점수 트래커',
+      title: 'TichuBoard',
       subtitle:
-        '플레이어를 배치하고, 라운드를 빠르게 입력하고, 새로고침 후에도 누적 점수를 안정적으로 유지합니다.',
+        '실전 플레이를 위한 모바일 중심 티츄 점수 동반 앱으로, 로컬 기록을 안정적으로 유지합니다.',
     },
     sections: {
       party: '플레이어 설정',


### PR DESCRIPTION
## Summary
- close #7
- rename the app surface to TichuBoard
- add a reusable logo component, favicon, and updated metadata
- align tests with the new brand copy

## Checks
- pnpm lint
- pnpm test
- pnpm build