### PR TITLE
feat: add landing start flow

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import App from './App'
 
 describe('App', () => {
@@ -6,13 +6,18 @@ describe('App', () => {
     localStorage.clear()
   })
 
-  it('renders the application heading', () => {
+  it('shows the landing screen before a game starts', () => {
     render(() => <App />)
 
-    expect(
-      screen.getByRole('heading', {
-        name: /tichuboard/i,
-      }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /tichuboard/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /start scoring/i })).toBeInTheDocument()
+  })
+
+  it('enters the scoring screen after pressing start', async () => {
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /start scoring/i }))
+
+    expect(screen.getByText(/party setup/i)).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { createSignal } from 'solid-js'
+import { Show, createSignal } from 'solid-js'
+import { LandingScreen } from './features/landing/LandingScreen'
 import { PartySetup } from './features/party-setup/PartySetup'
 import { RoundEntry } from './features/rounds/RoundEntry'
 import { Scoreboard } from './features/scoreboard/Scoreboard'
@@ -7,42 +8,47 @@ import { BrandLogo } from './shared/BrandLogo'
 import { GameProvider, useGame } from './state/game-context'
 
 function AppContent() {
-  const { t } = useGame()
+  const { state, t } = useGame()
   const [editingRoundId, setEditingRoundId] = createSignal<string | null>(null)
 
   return (
     <main class="min-h-screen bg-[var(--color-bg)] text-[var(--color-fg)]">
       <section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
-        <header class="rounded-[2.2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,191,105,0.16),rgba(255,255,255,0.04))] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.2)] backdrop-blur-sm motion-safe:animate-[fade-in_260ms_ease-out] sm:p-7">
-          <div class="flex items-center gap-3">
-            <div class="flex h-14 w-14 items-center justify-center rounded-[1.2rem] border border-white/12 bg-slate-950/35 shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
-              <BrandLogo class="h-10 w-10" />
+        <Show
+          when={state.hasStartedGame}
+          fallback={<LandingScreen />}
+        >
+          <header class="rounded-[2.2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,191,105,0.16),rgba(255,255,255,0.04))] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.2)] backdrop-blur-sm motion-safe:animate-[fade-in_260ms_ease-out] sm:p-7">
+            <div class="flex items-center gap-3">
+              <div class="flex h-14 w-14 items-center justify-center rounded-[1.2rem] border border-white/12 bg-slate-950/35 shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+                <BrandLogo class="h-10 w-10" />
+              </div>
+              <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
+                {t('app.badge')}
+              </div>
             </div>
-            <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
-              {t('app.badge')}
-            </div>
-          </div>
-          <h1 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">
-            {t('app.title')}
-          </h1>
-          <p class="mt-3 max-w-2xl text-sm leading-7 text-[var(--color-muted)] sm:text-base">
-            {t('app.subtitle')}
-          </p>
-        </header>
+            <h1 class="mt-5 max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">
+              {t('app.title')}
+            </h1>
+            <p class="mt-3 max-w-2xl text-sm leading-7 text-[var(--color-muted)] sm:text-base">
+              {t('app.subtitle')}
+            </p>
+          </header>
 
-        <div class="grid gap-4 xl:grid-cols-[1.12fr_0.88fr]">
-          <div class="grid gap-4">
-            <PartySetup />
-            <RoundEntry
-              editingRoundId={editingRoundId()}
-              onEditingRoundIdChange={setEditingRoundId}
-            />
+          <div class="grid gap-4 xl:grid-cols-[1.12fr_0.88fr]">
+            <div class="grid gap-4">
+              <PartySetup />
+              <RoundEntry
+                editingRoundId={editingRoundId()}
+                onEditingRoundIdChange={setEditingRoundId}
+              />
+            </div>
+            <div class="grid gap-4">
+              <Scoreboard onEditRound={setEditingRoundId} />
+              <SettingsPanel />
+            </div>
           </div>
-          <div class="grid gap-4">
-            <Scoreboard onEditRound={setEditingRoundId} />
-            <SettingsPanel />
-          </div>
-        </div>
+        </Show>
       </section>
     </main>
   )

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -75,6 +75,7 @@ export type GameSettings = {
 
 export type PersistedGameState = {
   schemaVersion: 1
+  hasStartedGame: boolean
   players: Player[]
   rounds: RoundRecord[]
   settings: GameSettings

--- a/src/features/landing/LandingScreen.tsx
+++ b/src/features/landing/LandingScreen.tsx
@@ -1,0 +1,54 @@
+import { BrandLogo } from '../../shared/BrandLogo'
+import { useGame } from '../../state/game-context'
+
+export function LandingScreen() {
+  const { startGame, t } = useGame()
+
+  return (
+    <section class="flex min-h-screen items-center py-6">
+      <div class="w-full rounded-[2.4rem] border border-white/10 bg-[linear-gradient(155deg,rgba(255,191,105,0.18),rgba(255,255,255,0.04))] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.24)] backdrop-blur-sm motion-safe:animate-[fade-in_260ms_ease-out] sm:p-7">
+        <div class="flex items-center gap-3">
+          <div class="flex h-16 w-16 items-center justify-center rounded-[1.4rem] border border-white/12 bg-slate-950/35 shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+            <BrandLogo class="h-11 w-11" />
+          </div>
+          <div class="inline-flex rounded-full border border-white/12 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.26em] text-[var(--color-accent)]">
+            {t('app.badge')}
+          </div>
+        </div>
+
+        <h1 class="mt-6 max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">
+          {t('app.title')}
+        </h1>
+        <p class="mt-4 max-w-2xl text-sm leading-7 text-[var(--color-muted)] sm:text-base">
+          {t('landing.subtitle')}
+        </p>
+
+        <div class="mt-6 grid gap-3 text-sm text-[var(--color-muted)] sm:grid-cols-3">
+          <article class="rounded-[1.6rem] border border-white/10 bg-slate-950/20 p-4">
+            <p class="font-semibold text-[var(--color-fg)]">{t('landing.featureFastTitle')}</p>
+            <p class="mt-2 leading-6">{t('landing.featureFastBody')}</p>
+          </article>
+          <article class="rounded-[1.6rem] border border-white/10 bg-slate-950/20 p-4">
+            <p class="font-semibold text-[var(--color-fg)]">{t('landing.featureLocalTitle')}</p>
+            <p class="mt-2 leading-6">{t('landing.featureLocalBody')}</p>
+          </article>
+          <article class="rounded-[1.6rem] border border-white/10 bg-slate-950/20 p-4">
+            <p class="font-semibold text-[var(--color-fg)]">{t('landing.featureBilingualTitle')}</p>
+            <p class="mt-2 leading-6">{t('landing.featureBilingualBody')}</p>
+          </article>
+        </div>
+
+        <div class="mt-7 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            type="button"
+            class="inline-flex min-h-12 items-center justify-center rounded-full bg-[var(--color-accent)] px-6 text-sm font-semibold text-slate-950 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5"
+            onClick={() => startGame()}
+          >
+            {t('landing.start')}
+          </button>
+          <p class="text-sm text-[var(--color-muted)]">{t('landing.caption')}</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import App from '../../App'
+import { seedStartedGameState } from '../../test/game-state'
 
 describe('PartySetup', () => {
   beforeEach(() => {
     localStorage.clear()
+    seedStartedGameState()
   })
 
   it('updates player names and swaps seats with drag and drop', async () => {

--- a/src/features/rounds/RoundEntry.test.tsx
+++ b/src/features/rounds/RoundEntry.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import App from '../../App'
+import { seedStartedGameState } from '../../test/game-state'
 
 describe('RoundEntry', () => {
   beforeEach(() => {
     localStorage.clear()
+    seedStartedGameState()
   })
 
   it('saves a round and updates cumulative totals', async () => {

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import App from '../../App'
+import { seedStartedGameState } from '../../test/game-state'
 
 describe('SettingsPanel', () => {
   beforeEach(() => {
     localStorage.clear()
+    seedStartedGameState()
     document.documentElement.dataset.theme = 'dark'
   })
 

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -9,6 +9,18 @@ const dictionaries = {
       subtitle:
         'A fast, mobile-first score companion for live Tichu sessions with resilient local history.',
     },
+    landing: {
+      subtitle:
+        'Start a new table-ready score session, keep round history locally, and switch language or theme any time.',
+      start: 'Start scoring',
+      caption: 'Your game stays in this browser until you reset it.',
+      featureFastTitle: 'Fast round entry',
+      featureFastBody: 'Track Tichu calls, first-out, and team card points without breaking table flow.',
+      featureLocalTitle: 'Local persistence',
+      featureLocalBody: 'Player names, seats, rounds, and preferences stay available after reloads.',
+      featureBilingualTitle: 'Bilingual setup',
+      featureBilingualBody: 'English and Korean are available from the first session with dark mode included.',
+    },
     sections: {
       party: 'Party Setup',
       round: 'Round Entry',
@@ -86,6 +98,18 @@ const dictionaries = {
       title: 'TichuBoard',
       subtitle:
         '실전 플레이를 위한 모바일 중심 티츄 점수 동반 앱으로, 로컬 기록을 안정적으로 유지합니다.',
+    },
+    landing: {
+      subtitle:
+        '새 점수 세션을 시작하고, 라운드 기록을 로컬에 유지하며, 언어와 테마를 언제든 바꿀 수 있습니다.',
+      start: '시작하기',
+      caption: '게임 데이터는 초기화 전까지 이 브라우저에 유지됩니다.',
+      featureFastTitle: '빠른 라운드 입력',
+      featureFastBody: '티츄 콜, 첫 아웃, 팀 카드 점수를 끊김 없이 기록할 수 있습니다.',
+      featureLocalTitle: '로컬 저장',
+      featureLocalBody: '플레이어 이름, 자리, 라운드, 설정이 새로고침 후에도 유지됩니다.',
+      featureBilingualTitle: '이중 언어 지원',
+      featureBilingualBody: '첫 화면부터 영어와 한국어를 지원하고 다크 모드도 함께 제공합니다.',
     },
     sections: {
       party: '플레이어 설정',

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -41,6 +41,7 @@ type GameContextValue = {
   systemTheme: () => Exclude<ThemeMode, 'system'>
   effectiveTheme: () => Exclude<ThemeMode, 'system'>
   t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
+  startGame: () => void
   updatePlayerName: (playerId: PlayerId, name: string) => void
   swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
   setLanguage: (language: PersistedGameState['settings']['language']) => void
@@ -117,6 +118,7 @@ export const GameProvider: ParentComponent = (props) => {
     systemTheme,
     effectiveTheme,
     t: (key, args) => translate()(key, args),
+    startGame: () => setState('hasStartedGame', true),
     updatePlayerName: (playerId, name) => {
       const trimmedName = name.trimStart().slice(0, 24)
 

--- a/src/storage/game-storage.test.ts
+++ b/src/storage/game-storage.test.ts
@@ -12,6 +12,7 @@ import {
 function createMockState(): PersistedGameState {
   return {
     schemaVersion: 1,
+    hasStartedGame: true,
     players: createDefaultPlayers(),
     rounds: [],
     settings: createDefaultSettings(),
@@ -39,6 +40,20 @@ describe('game storage', () => {
 
   it('returns null for malformed serialized input', () => {
     expect(deserializeGameState('{not-json')).toBeNull()
+  })
+
+  it('hydrates older payloads without hasStartedGame by inferring from rounds', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        players: createDefaultPlayers(),
+        rounds: [],
+        settings: createDefaultSettings(),
+      }),
+    )
+
+    expect(loadGameState(localStorage)).toEqual(createInitialGameState())
   })
 
   it('can clear the saved game state', () => {

--- a/src/storage/game-storage.ts
+++ b/src/storage/game-storage.ts
@@ -7,6 +7,7 @@ export const CURRENT_SCHEMA_VERSION = 1 as const
 export function createInitialGameState(): PersistedGameState {
   return {
     schemaVersion: CURRENT_SCHEMA_VERSION,
+    hasStartedGame: false,
     players: createDefaultPlayers(),
     rounds: [],
     settings: createDefaultSettings(),
@@ -26,7 +27,11 @@ export function migratePersistedState(value: unknown): PersistedGameState | null
     return null
   }
 
-  return value as PersistedGameState
+  return {
+    ...(value as Omit<PersistedGameState, 'hasStartedGame'>),
+    hasStartedGame:
+      typeof value.hasStartedGame === 'boolean' ? value.hasStartedGame : value.rounds.length > 0,
+  }
 }
 
 export function deserializeGameState(value: string): PersistedGameState | null {

--- a/src/test/game-state.ts
+++ b/src/test/game-state.ts
@@ -1,0 +1,15 @@
+import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
+import { STORAGE_KEY } from '../storage/game-storage'
+
+export function seedStartedGameState() {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      schemaVersion: 1,
+      hasStartedGame: true,
+      players: createDefaultPlayers(),
+      rounds: [],
+      settings: createDefaultSettings(),
+    }),
+  )
+}


### PR DESCRIPTION
## Summary
- close #11
- add a landing screen for fresh sessions with a start action
- persist whether the user has started a game in local storage
- update app tests to distinguish landing and in-game flows

## Checks
- pnpm lint
- pnpm test
- pnpm build