### PR TITLE
feat: redesign the party setup table

### DIFF
--- a/src/domain/defaults.ts
+++ b/src/domain/defaults.ts
@@ -1,12 +1,118 @@
 import { PLAYER_IDS, SEATS } from './constants'
-import type { GameSettings, Player, PlayerTichuCallMap } from './types'
+import type { GameSettings, Language, Player, PlayerTichuCallMap } from './types'
 
-const DEFAULT_PLAYER_NAMES = ['Phoenix', 'Dragon', 'Pagoda', 'Jade'] as const
+const ENGLISH_PLAYER_NAMES = [
+  'Avery',
+  'Bennett',
+  'Cameron',
+  'Dakota',
+  'Ellis',
+  'Finley',
+  'Gray',
+  'Harper',
+  'Indigo',
+  'Jules',
+  'Kai',
+  'Logan',
+  'Marlowe',
+  'Nova',
+  'Oakley',
+  'Parker',
+  'Quinn',
+  'Reese',
+  'Sawyer',
+  'Tatum',
+  'Uma',
+  'Vale',
+  'Wren',
+  'Xen',
+  'Yael',
+  'Zuri',
+  'Arden',
+  'Blake',
+  'Cleo',
+  'Drew',
+  'Emery',
+  'Flynn',
+  'Gale',
+  'Hollis',
+  'Ira',
+  'Jordan',
+  'Kendall',
+  'Lane',
+  'Morgan',
+  'Nico',
+  'Onyx',
+  'Peyton',
+  'River',
+  'Sage',
+  'Teagan',
+  'Urban',
+  'Vesper',
+  'Winter',
+  'Zephyr',
+  'Atlas',
+] as const
+
+const KOREAN_PLAYER_NAMES = [
+  '민준',
+  '서준',
+  '도윤',
+  '예준',
+  '시우',
+  '주원',
+  '지호',
+  '하준',
+  '유준',
+  '준우',
+  '서연',
+  '서윤',
+  '지우',
+  '하은',
+  '하윤',
+  '민서',
+  '지유',
+  '채원',
+  '수아',
+  '예은',
+  '도현',
+  '지환',
+  '은우',
+  '현우',
+  '건우',
+  '우진',
+  '윤호',
+  '정우',
+  '시윤',
+  '태윤',
+  '소율',
+  '예린',
+  '지원',
+  '윤서',
+  '시아',
+  '가은',
+  '다은',
+  '채아',
+  '서아',
+  '유나',
+  '준영',
+  '민재',
+  '태민',
+  '현서',
+  '하람',
+  '도연',
+  '주아',
+  '나윤',
+  '로아',
+  '이안',
+] as const
 
 export function createDefaultPlayers(): Player[] {
+  const initialNames = ENGLISH_PLAYER_NAMES.slice(0, PLAYER_IDS.length)
+
   return PLAYER_IDS.map((id, index) => ({
     id,
-    name: DEFAULT_PLAYER_NAMES[index],
+    name: initialNames[index]!,
     seat: SEATS[index],
   }))
 }
@@ -25,4 +131,15 @@ export function createDefaultSettings(): GameSettings {
     language: 'en',
     theme: 'system',
   }
+}
+
+export function getRandomPlayerName(language: Language, currentName?: string) {
+  const pool = language === 'ko' ? KOREAN_PLAYER_NAMES : ENGLISH_PLAYER_NAMES
+  const availableNames = pool.filter((name) => name !== currentName)
+
+  if (availableNames.length === 0) {
+    return currentName ?? pool[0]
+  }
+
+  return availableNames[Math.floor(Math.random() * availableNames.length)]!
 }

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -24,4 +24,22 @@ describe('PartySetup', () => {
 
     expect(within(screen.getByTestId('seat-east')).getByDisplayValue('Alice')).toBeInTheDocument()
   })
+
+  it('can reroll a name and move the player with the seat picker', async () => {
+    render(() => <App />)
+
+    const northSeat = screen.getByTestId('seat-north')
+    const northNameBefore = (within(northSeat).getByRole('textbox') as HTMLInputElement).value
+
+    await fireEvent.click(within(northSeat).getByRole('button', { name: /reroll random name/i }))
+
+    const rerolledName = (within(northSeat).getByRole('textbox') as HTMLInputElement).value
+    expect(rerolledName).not.toBe(northNameBefore)
+
+    await fireEvent.change(screen.getByLabelText(/seat picker for north/i), {
+      target: { value: 'west' },
+    })
+
+    expect(within(screen.getByTestId('seat-west')).getByDisplayValue(rerolledName)).toBeInTheDocument()
+  })
 })

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -1,78 +1,152 @@
-import { For, createSignal } from 'solid-js'
+import { For, createMemo, createSignal } from 'solid-js'
+import { SEATS } from '../../domain/constants'
+import { getRandomPlayerName } from '../../domain/defaults'
 import { useGame } from '../../state/game-context'
-import type { PlayerId } from '../../domain/types'
+import type { PlayerId, Seat } from '../../domain/types'
 
-const seatOrder = ['north', 'east', 'south', 'west'] as const
+const seatLayouts: { seat: Seat; className: string }[] = [
+  { seat: 'north', className: 'col-start-2 row-start-1' },
+  { seat: 'west', className: 'col-start-1 row-start-2' },
+  { seat: 'east', className: 'col-start-3 row-start-2' },
+  { seat: 'south', className: 'col-start-2 row-start-3' },
+]
 
 export function PartySetup() {
-  const { state, swapPlayerSeats, updatePlayerName, t } = useGame()
+  const { assignPlayerSeat, state, swapPlayerSeats, updatePlayerName, t } = useGame()
   const [draggingPlayerId, setDraggingPlayerId] = createSignal<PlayerId | null>(null)
 
-  const playersBySeat = () =>
-    seatOrder
-      .map((seat) => state.players.find((player) => player.seat === seat))
-      .filter((player): player is NonNullable<typeof player> => Boolean(player))
+  const playersBySeat = createMemo(() =>
+    seatLayouts
+      .map(({ seat, className }) => {
+        const player = state.players.find((item) => item.seat === seat)
+
+        return player ? { player, className } : null
+      })
+      .filter((item): item is { player: (typeof state.players)[number]; className: string } => Boolean(item)),
+  )
 
   return (
-    <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
+    <section class="rounded-[2rem] border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-5">
       <div class="flex items-center justify-between gap-3">
         <div>
           <p class="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--color-accent)]">
             {t('sections.party')}
           </p>
-          <p class="mt-2 text-sm leading-6 text-[var(--color-muted)]">{t('party.hint')}</p>
+          <p class="mt-2 text-xs leading-5 text-[var(--color-muted)] sm:text-sm">{t('party.hint')}</p>
         </div>
       </div>
-      <div class="mt-5 grid gap-3 sm:grid-cols-2">
+      <div
+        class="mt-4 grid min-h-[22rem] grid-cols-[minmax(0,1fr)_minmax(4.75rem,0.84fr)_minmax(0,1fr)] grid-rows-[auto_minmax(5rem,1fr)_auto] gap-3"
+        aria-label={t('party.tableLabel')}
+      >
+        <div class="col-start-2 row-start-2 flex items-center justify-center">
+          <div class="flex h-full min-h-28 w-full max-w-32 items-center justify-center rounded-[2.2rem] border border-white/12 bg-[radial-gradient(circle_at_top,rgba(255,191,105,0.24),rgba(15,23,42,0.9))] p-3 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
+            <div>
+              <p class="text-[10px] uppercase tracking-[0.26em] text-[var(--color-accent)]">
+                {t('party.tableCenter')}
+              </p>
+              <p class="mt-2 text-xs leading-5 text-[var(--color-muted)]">{t('teams.northSouth')}</p>
+              <p class="text-xs leading-5 text-[var(--color-muted)]">{t('teams.eastWest')}</p>
+            </div>
+          </div>
+        </div>
+
         <For each={playersBySeat()}>
-          {(player) => {
-            const teamKey = player.seat === 'north' || player.seat === 'south' ? 'northSouth' : 'eastWest'
+          {(entry) => {
+            const teamKey =
+              entry.player.seat === 'north' || entry.player.seat === 'south'
+                ? 'northSouth'
+                : 'eastWest'
 
             return (
-              <article
-                class="group rounded-[1.6rem] border border-white/10 bg-[var(--color-surface)] p-4 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5"
-                draggable="true"
-                onDragStart={() => setDraggingPlayerId(player.id)}
-                onDragEnd={() => setDraggingPlayerId(null)}
-                onDragOver={(event) => event.preventDefault()}
-                onDrop={() => {
-                  const sourceId = draggingPlayerId()
+            <article
+              class={`${entry.className} group rounded-[1.5rem] border border-white/10 bg-[var(--color-surface)] p-3 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5`}
+              draggable="true"
+              onDragStart={() => setDraggingPlayerId(entry.player.id)}
+              onDragEnd={() => setDraggingPlayerId(null)}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={() => {
+                const sourceId = draggingPlayerId()
 
-                  if (!sourceId) {
-                    return
-                  }
+                if (!sourceId) {
+                  return
+                }
 
-                  swapPlayerSeats(sourceId, player.id)
-                  setDraggingPlayerId(null)
-                }}
-                data-testid={`seat-${player.seat}`}
-              >
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <p class="text-xs uppercase tracking-[0.22em] text-[var(--color-accent)]">
-                      {t(`seats.${player.seat}`)}
-                    </p>
-                    <p class="mt-2 text-sm text-[var(--color-muted)]">
-                      {t('party.teamLabel', { team: t(`teams.${teamKey}`) })}
-                    </p>
-                  </div>
-                  <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-[var(--color-muted)]">
-                    {player.id}
+                swapPlayerSeats(sourceId, entry.player.id)
+                setDraggingPlayerId(null)
+              }}
+              data-testid={`seat-${entry.player.seat}`}
+            >
+              <div class="flex items-start justify-between gap-2">
+                <div>
+                  <p class="text-[11px] uppercase tracking-[0.22em] text-[var(--color-accent)]">
+                    {t(`seats.${entry.player.seat}`)}
+                  </p>
+                  <p class="mt-1 text-xs text-[var(--color-muted)]">
+                    {t('party.teamLabel', { team: t(`teams.${teamKey}`) })}
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-black/15 text-[var(--color-fg)]"
+                    aria-label={t('party.rerollName')}
+                    onClick={() =>
+                      updatePlayerName(
+                        entry.player.id,
+                        getRandomPlayerName(state.settings.language, entry.player.name),
+                      )
+                    }
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M4 9H14L11 6M20 15H10L13 18M6 6V12C6 15.3137 8.68629 18 12 18H13M18 18V12C18 8.68629 15.3137 6 12 6H11"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </button>
+                  <span class="rounded-full border border-white/10 px-2 py-1 text-[10px] text-[var(--color-muted)]">
+                    {entry.player.id}
                   </span>
                 </div>
-                <label class="mt-4 block">
-                  <span class="sr-only">
-                    {t('party.nameLabel', { seat: t(`seats.${player.seat}`) })}
-                  </span>
-                  <input
-                    class="w-full rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-base text-[var(--color-fg)] outline-none transition-colors placeholder:text-[var(--color-muted)] focus:border-[var(--color-accent)]"
-                    value={player.name}
-                    onInput={(event) => updatePlayerName(player.id, event.currentTarget.value)}
-                    placeholder={t(`seats.${player.seat}`)}
-                    data-testid={`player-name-${player.id}`}
-                  />
-                </label>
-              </article>
+              </div>
+
+              <label class="mt-3 block">
+                <span class="sr-only">
+                  {t('party.nameLabel', { seat: t(`seats.${entry.player.seat}`) })}
+                </span>
+                <input
+                  class="w-full rounded-2xl border border-white/10 bg-black/15 px-3 py-2.5 text-sm text-[var(--color-fg)] outline-none transition-colors placeholder:text-[var(--color-muted)] focus:border-[var(--color-accent)]"
+                  value={entry.player.name}
+                  onInput={(event) => updatePlayerName(entry.player.id, event.currentTarget.value)}
+                  placeholder={t(`seats.${entry.player.seat}`)}
+                  data-testid={`player-name-${entry.player.id}`}
+                />
+              </label>
+
+              <label class="mt-2 block">
+                <span class="sr-only">
+                  {t('party.seatPickerLabel', { seat: t(`seats.${entry.player.seat}`) })}
+                </span>
+                <select
+                  class="w-full rounded-2xl border border-white/10 bg-black/15 px-3 py-2.5 text-sm text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
+                  aria-label={t('party.seatPicker', { seat: t(`seats.${entry.player.seat}`) })}
+                  value={entry.player.seat}
+                  onChange={(event) => assignPlayerSeat(entry.player.id, event.currentTarget.value as Seat)}
+                >
+                  <For each={SEATS}>{(seat) => <option value={seat}>{t(`seats.${seat}`)}</option>}</For>
+                </select>
+              </label>
+            </article>
             )
           }}
         </For>

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -39,8 +39,13 @@ const dictionaries = {
       eastWest: 'East + West',
     },
     party: {
-      hint: 'Drag player cards onto another seat to swap positions.',
+      hint: 'Drag cards or use the seat picker to keep names fixed while swapping chairs.',
       nameLabel: '{{ seat }} player name',
+      rerollName: 'Reroll random name',
+      seatPicker: 'Seat picker for {{ seat }}',
+      seatPickerLabel: 'Move {{ seat }} player',
+      tableLabel: 'Table overview',
+      tableCenter: 'Tabletop setup',
       teamLabel: 'Team {{ team }}',
     },
     round: {
@@ -134,8 +139,13 @@ const dictionaries = {
       eastWest: '동 + 서',
     },
     party: {
-      hint: '플레이어 카드를 다른 자리로 드래그하면 자리가 서로 바뀝니다.',
+      hint: '카드를 드래그하거나 자리 선택기를 사용해 이름을 유지한 채 좌석을 바꿀 수 있습니다.',
       nameLabel: '{{ seat }} 플레이어 이름',
+      rerollName: '랜덤 이름 다시 뽑기',
+      seatPicker: '{{ seat }} 자리 선택기',
+      seatPickerLabel: '{{ seat }} 플레이어 자리 변경',
+      tableLabel: '테이블 개요',
+      tableCenter: '테이블탑 배치',
       teamLabel: '{{ team }} 팀',
     },
     round: {

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -22,6 +22,7 @@ import type {
   PlayerId,
   RoundInput,
   RoundRecord,
+  Seat,
   TeamId,
   ThemeMode,
 } from '../domain/types'
@@ -43,6 +44,7 @@ type GameContextValue = {
   t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
   startGame: () => void
   updatePlayerName: (playerId: PlayerId, name: string) => void
+  assignPlayerSeat: (playerId: PlayerId, seat: Seat) => void
   swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
   setLanguage: (language: PersistedGameState['settings']['language']) => void
   setTheme: (theme: ThemeMode) => void
@@ -127,6 +129,29 @@ export const GameProvider: ParentComponent = (props) => {
         (player) => player.id === playerId,
         'name',
         (currentName) => trimmedName || currentName,
+      )
+    },
+    assignPlayerSeat: (playerId, seat) => {
+      const sourcePlayer = state.players.find((player) => player.id === playerId)
+      const targetPlayer = state.players.find((player) => player.seat === seat)
+
+      if (!sourcePlayer || !targetPlayer || sourcePlayer.seat === seat) {
+        return
+      }
+
+      setState(
+        'players',
+        state.players.map((player) => {
+          if (player.id === playerId) {
+            return { ...player, seat }
+          }
+
+          if (player.id === targetPlayer.id) {
+            return { ...player, seat: sourcePlayer.seat }
+          }
+
+          return player
+        }),
       )
     },
     swapPlayerSeats: (sourcePlayerId, targetPlayerId) => {


### PR DESCRIPTION
## Summary
- close #10
- redesign party setup around a tabletop layout that fits the mobile flow better
- add random English and Korean name pools with per-seat reroll actions
- keep drag-and-drop seat swaps and add a seat picker fallback for mobile adjustments

## Checks
- pnpm lint
- pnpm test
- pnpm build