### PR TITLE
refactor: add source alias imports

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
-import App from './App'
-import { seedStartedGameState } from './test/game-state'
+import App from '@/App'
+import { seedStartedGameState } from '@/test/game-state'
 
 describe('App', () => {
   beforeEach(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { Show, createEffect, createSignal, onCleanup, onMount } from 'solid-js'
-import { ApplicationControlBar } from './features/app/ApplicationControlBar'
-import { GameTabBar } from './features/app/GameTabBar'
-import { GameplayPages } from './features/app/GameplayPages'
-import { LandingScreen } from './features/landing/LandingScreen'
-import { SettingsDialog } from './features/settings/SettingsDialog'
-import { GameProvider, useGame } from './state/game-context'
+import { ApplicationControlBar } from '@/features/app/ApplicationControlBar'
+import { GameTabBar } from '@/features/app/GameTabBar'
+import { GameplayPages } from '@/features/app/GameplayPages'
+import { LandingScreen } from '@/features/landing/LandingScreen'
+import { SettingsDialog } from '@/features/settings/SettingsDialog'
+import { GameProvider, useGame } from '@/state/game-context'
 import {
   getAdjacentRoute,
   getDefaultRoute,
@@ -13,7 +13,7 @@ import {
   isInGameRoute,
   type AppRoute,
   type InGameRoute,
-} from './shared/routes'
+} from '@/shared/routes'
 
 function AppContent() {
   const { state } = useGame()

--- a/src/features/app/ApplicationControlBar.tsx
+++ b/src/features/app/ApplicationControlBar.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
-import { BrandLogo } from '../../shared/BrandLogo'
-import { useGame } from '../../state/game-context'
+import { BrandLogo } from '@/shared/BrandLogo'
+import { useGame } from '@/state/game-context'
 
 type ApplicationControlBarProps = {
   onOpenSettings: () => void

--- a/src/features/app/GameTabBar.tsx
+++ b/src/features/app/GameTabBar.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx'
 import { For } from 'solid-js'
-import type { InGameRoute } from '../../shared/routes'
-import { inGameRoutes } from '../../shared/routes'
-import { useGame } from '../../state/game-context'
+import type { InGameRoute } from '@/shared/routes'
+import { inGameRoutes } from '@/shared/routes'
+import { useGame } from '@/state/game-context'
 
 type GameTabBarProps = {
   activeRoute: InGameRoute

--- a/src/features/app/GameplayPages.tsx
+++ b/src/features/app/GameplayPages.tsx
@@ -1,9 +1,9 @@
 import { Match, Switch } from 'solid-js'
+import { PartySetup } from '@/features/party-setup/PartySetup'
+import { RoundEntry } from '@/features/rounds/RoundEntry'
+import { HistoryPanel, ResultsSummary } from '@/features/scoreboard/Scoreboard'
+import { useGame } from '@/state/game-context'
 import { PageSection } from './PageSection'
-import { PartySetup } from '../party-setup/PartySetup'
-import { RoundEntry } from '../rounds/RoundEntry'
-import { HistoryPanel, ResultsSummary } from '../scoreboard/Scoreboard'
-import { useGame } from '../../state/game-context'
 
 type GameplayPagesProps = {
   route: 'party' | 'round' | 'results' | 'history'

--- a/src/features/landing/LandingScreen.tsx
+++ b/src/features/landing/LandingScreen.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
-import { BrandLogo } from '../../shared/BrandLogo'
-import { useGame } from '../../state/game-context'
+import { BrandLogo } from '@/shared/BrandLogo'
+import { useGame } from '@/state/game-context'
 
 export function LandingScreen() {
   const { startGame, t } = useGame()

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
-import App from '../../App'
-import { seedStartedGameState } from '../../test/game-state'
+import App from '@/App'
+import { seedStartedGameState } from '@/test/game-state'
 
 describe('PartySetup', () => {
   beforeEach(() => {

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx'
 import { For, createMemo, createSignal } from 'solid-js'
-import { SEATS } from '../../domain/constants'
-import { getRandomPlayerName } from '../../domain/defaults'
-import { useGame } from '../../state/game-context'
-import type { PlayerId, Seat } from '../../domain/types'
+import { SEATS } from '@/domain/constants'
+import { getRandomPlayerName } from '@/domain/defaults'
+import type { PlayerId, Seat } from '@/domain/types'
+import { useGame } from '@/state/game-context'
 
 const seatLayouts: { seat: Seat; className: string }[] = [
   { seat: 'north', className: 'col-start-2 row-start-1' },

--- a/src/features/rounds/RoundEntry.test.tsx
+++ b/src/features/rounds/RoundEntry.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
-import App from '../../App'
-import { seedStartedGameState } from '../../test/game-state'
+import App from '@/App'
+import { seedStartedGameState } from '@/test/game-state'
 
 describe('RoundEntry', () => {
   beforeEach(() => {

--- a/src/features/rounds/RoundEntry.tsx
+++ b/src/features/rounds/RoundEntry.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx'
 import { For, Show, createEffect, createMemo, createSignal } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
-import { createDefaultTichuCalls } from '../../domain/defaults'
-import { validateRoundInput } from '../../domain/scoring'
-import type { Player, RoundInput, TeamId, TichuCall } from '../../domain/types'
-import { useGame } from '../../state/game-context'
+import { createDefaultTichuCalls } from '@/domain/defaults'
+import { validateRoundInput } from '@/domain/scoring'
+import type { Player, RoundInput, TeamId, TichuCall } from '@/domain/types'
+import { useGame } from '@/state/game-context'
 
 type RoundEntryProps = {
   editingRoundId: string | null

--- a/src/features/scoreboard/Scoreboard.tsx
+++ b/src/features/scoreboard/Scoreboard.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { For, Show } from 'solid-js'
-import { useGame } from '../../state/game-context'
-import type { TeamId } from '../../domain/types'
+import type { TeamId } from '@/domain/types'
+import { useGame } from '@/state/game-context'
 
 type ScoreboardProps = {
   onEditRound: (roundId: string) => void

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { For, Show } from 'solid-js'
-import type { ThemeMode } from '../../domain/types'
-import { useGame } from '../../state/game-context'
+import type { ThemeMode } from '@/domain/types'
+import { useGame } from '@/state/game-context'
 
 const themeModes: ThemeMode[] = ['system', 'light', 'dark']
 

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
-import App from '../../App'
-import { seedStartedGameState } from '../../test/game-state'
+import App from '@/App'
+import { seedStartedGameState } from '@/test/game-state'
 
 describe('SettingsPanel', () => {
   beforeEach(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 /* @refresh reload */
 import { render } from 'solid-js/web'
-import './index.css'
-import App from './App'
+import '@/index.css'
+import App from '@/App'
 
 const root = document.getElementById('root')
 

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1,5 +1,5 @@
 import { flatten, resolveTemplate, translator } from '@solid-primitives/i18n'
-import type { Language } from '../domain/types'
+import type { Language } from '@/domain/types'
 
 const dictionaries = {
   en: flatten({

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -8,14 +8,13 @@ import {
   type ParentComponent,
 } from 'solid-js'
 import { createStore, reconcile, unwrap } from 'solid-js/store'
-import { createTranslator, type TranslationKey } from '../shared/i18n'
-import { getTeamIdBySeat } from '../domain/helpers'
+import { getTeamIdBySeat } from '@/domain/helpers'
 import {
   calculateCumulativeScores,
   calculateRoundScore,
   getGameStatus,
   getLeadingTeamId,
-} from '../domain/scoring'
+} from '@/domain/scoring'
 import type {
   PersistedGameState,
   Player,
@@ -25,13 +24,14 @@ import type {
   Seat,
   TeamId,
   ThemeMode,
-} from '../domain/types'
+} from '@/domain/types'
 import {
   clearGameState,
   createInitialGameState,
   loadGameState,
   saveGameState,
-} from '../storage/game-storage'
+} from '@/storage/game-storage'
+import { createTranslator, type TranslationKey } from '@/shared/i18n'
 
 type GameContextValue = {
   state: PersistedGameState

--- a/src/storage/game-storage.test.ts
+++ b/src/storage/game-storage.test.ts
@@ -1,5 +1,5 @@
-import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
-import type { PersistedGameState } from '../domain/types'
+import { createDefaultPlayers, createDefaultSettings } from '@/domain/defaults'
+import type { PersistedGameState } from '@/domain/types'
 import {
   clearGameState,
   createInitialGameState,
@@ -7,7 +7,7 @@ import {
   loadGameState,
   saveGameState,
   STORAGE_KEY,
-} from './game-storage'
+} from '@/storage/game-storage'
 
 function createMockState(): PersistedGameState {
   return {

--- a/src/storage/game-storage.ts
+++ b/src/storage/game-storage.ts
@@ -1,5 +1,5 @@
-import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
-import type { PersistedGameState } from '../domain/types'
+import { createDefaultPlayers, createDefaultSettings } from '@/domain/defaults'
+import type { PersistedGameState } from '@/domain/types'
 
 export const STORAGE_KEY = 'tichu-board-r1:v1'
 export const CURRENT_SCHEMA_VERSION = 1 as const

--- a/src/test/game-state.ts
+++ b/src/test/game-state.ts
@@ -1,6 +1,6 @@
-import { createDefaultPlayers, createDefaultSettings } from '../domain/defaults'
-import { getHashForRoute, type AppRoute } from '../shared/routes'
-import { STORAGE_KEY } from '../storage/game-storage'
+import { createDefaultPlayers, createDefaultSettings } from '@/domain/defaults'
+import { getHashForRoute, type AppRoute } from '@/shared/routes'
+import { STORAGE_KEY } from '@/storage/game-storage'
 
 export function seedStartedGameState(route: AppRoute = 'party') {
   localStorage.setItem(

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,10 @@
     "noEmit": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -13,6 +13,10 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
+import path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vitest/config'
 import solid from 'vite-plugin-solid'
 
 export default defineConfig({
   base: '/tichu-board-r1/',
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   plugins: [solid(), tailwindcss()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add a project-wide @ alias for src in TypeScript and Vite
- refactor deep relative imports in source and tests to use @/
- keep app, tests, and build working with the new import convention

Closes #25

## Validation
- pnpm lint
- pnpm test
- pnpm build