### PR TITLE
feat: rework app chrome and landing replay

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -51,4 +51,20 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: /round entry/i })).toBeInTheDocument()
     expect(window.location.hash).toBe('#/round')
   })
+
+  it('can revisit the landing screen and continue the current game', async () => {
+    seedStartedGameState('results')
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /open settings/i }))
+    await fireEvent.click(screen.getByRole('button', { name: /show start screen/i }))
+
+    expect(screen.getByRole('button', { name: /continue game/i })).toBeInTheDocument()
+    expect(window.location.hash).toBe('#/start')
+
+    await fireEvent.click(screen.getByRole('button', { name: /continue game/i }))
+
+    expect(screen.getByRole('heading', { name: /party setup/i })).toBeInTheDocument()
+    expect(window.location.hash).toBe('#/party')
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,19 +98,17 @@ function AppContent() {
   createEffect(() => {
     if (!state.hasStartedGame && route() !== 'start') {
       navigate('start', { replace: true })
-      return
-    }
-
-    if (state.hasStartedGame && route() === 'start') {
-      navigate(getDefaultRoute(true), { replace: true })
     }
   })
 
   return (
     <main class="min-h-screen bg-(--color-bg) text-(--color-fg)">
       <section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-6 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:py-8 lg:px-8">
-        <Show when={state.hasStartedGame} fallback={<LandingScreen />}>
-          <ApplicationControlBar onOpenSettings={() => setIsSettingsOpen(true)} />
+        <Show
+          when={route() !== 'start'}
+          fallback={<LandingScreen onEnterGame={() => navigate(getDefaultRoute(true))} />}
+        >
+          <ApplicationControlBar />
 
           <div class="min-h-[calc(100vh-15rem)]" data-testid={`page-${route()}`}>
             <GameplayPages
@@ -124,11 +122,16 @@ function AppContent() {
             />
           </div>
 
-          <GameTabBar activeRoute={currentGameRoute()} onNavigate={navigate} />
+          <GameTabBar
+            activeRoute={currentGameRoute()}
+            onNavigate={navigate}
+            onOpenSettings={() => setIsSettingsOpen(true)}
+          />
 
           <SettingsDialog
             isOpen={isSettingsOpen()}
             onClose={() => setIsSettingsOpen(false)}
+            onShowLanding={() => navigate('start')}
           />
         </Show>
       </section>

--- a/src/features/app/ApplicationControlBar.tsx
+++ b/src/features/app/ApplicationControlBar.tsx
@@ -2,17 +2,12 @@ import clsx from 'clsx'
 import { BrandLogo } from '@/shared/BrandLogo'
 import { useGame } from '@/state/game-context'
 
-type ApplicationControlBarProps = {
-  onOpenSettings: () => void
-}
-
-export function ApplicationControlBar(props: ApplicationControlBarProps) {
+export function ApplicationControlBar() {
   const { t } = useGame()
 
   return (
     <header
       class={clsx(
-        'sticky top-4 z-20',
         'rounded-[1.8rem] border border-white/10',
         'bg-[color-mix(in_srgb,var(--color-surface)_82%,transparent)]',
         'p-3 shadow-[0_20px_60px_rgba(0,0,0,0.2)] backdrop-blur-xl',
@@ -41,42 +36,6 @@ export function ApplicationControlBar(props: ApplicationControlBarProps) {
           </div>
           <p class="mt-1 truncate text-xs text-(--color-muted)">{t('app.controlSubtitle')}</p>
         </div>
-
-        <button
-          type="button"
-          class={clsx(
-            'inline-flex h-11 min-w-11 items-center justify-center rounded-full',
-            'border border-white/10 bg-slate-950/35 px-4',
-            'text-sm font-medium text-(--color-fg)',
-            'transition-transform duration-200 ease-out',
-            'motion-safe:hover:-translate-y-0.5',
-          )}
-          aria-label={t('settings.open')}
-          onClick={() => props.onOpenSettings()}
-        >
-          <svg
-            aria-hidden="true"
-            class="h-4 w-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 8.5A3.5 3.5 0 1 0 12 15.5A3.5 3.5 0 1 0 12 8.5Z"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.8"
-            />
-            <path
-              d="M19.4 15A1 1 0 0 0 19.6 16.1L19.7 16.2A1.2 1.2 0 0 1 18 17.9L17.9 17.8A1 1 0 0 0 16.8 17.6A1 1 0 0 0 16.2 18.5V18.8A1.2 1.2 0 0 1 13.8 18.8V18.7A1 1 0 0 0 13.2 17.8A1 1 0 0 0 12.1 17.9L12 18A1.2 1.2 0 0 1 10.3 16.3L10.4 16.2A1 1 0 0 0 10.6 15.1A1 1 0 0 0 9.7 14.5H9.4A1.2 1.2 0 0 1 9.4 12.1H9.5A1 1 0 0 0 10.4 11.5A1 1 0 0 0 10.2 10.4L10.1 10.3A1.2 1.2 0 0 1 11.8 8.6L11.9 8.7A1 1 0 0 0 13 8.9A1 1 0 0 0 13.6 8V7.7A1.2 1.2 0 0 1 16 7.7V7.8A1 1 0 0 0 16.6 8.7A1 1 0 0 0 17.7 8.5L17.8 8.4A1.2 1.2 0 0 1 19.5 10.1L19.4 10.2A1 1 0 0 0 19.2 11.3A1 1 0 0 0 20.1 11.9H20.4A1.2 1.2 0 0 1 20.4 14.3H20.3A1 1 0 0 0 19.4 15Z"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.8"
-            />
-          </svg>
-        </button>
       </div>
     </header>
   )

--- a/src/features/app/GameTabBar.tsx
+++ b/src/features/app/GameTabBar.tsx
@@ -7,10 +7,21 @@ import { useGame } from '@/state/game-context'
 type GameTabBarProps = {
   activeRoute: InGameRoute
   onNavigate: (route: InGameRoute) => void
+  onOpenSettings: () => void
+}
+
+const tabIcons: Record<InGameRoute | 'settings', string> = {
+  party: 'M4 9.5H20M7.5 4V9.5M16.5 4V9.5M6 20H18A2 2 0 0 0 20 18V9.5H4V18A2 2 0 0 0 6 20Z',
+  round: 'M12 3V21M3 12H21M5.5 5.5L18.5 18.5M18.5 5.5L5.5 18.5',
+  results: 'M5 19V10M12 19V5M19 19V13',
+  history: 'M12 7V12L15 15M4 12A8 8 0 1 0 6.34 6.34M4 4V9H9',
+  settings:
+    'M12 8.5A3.5 3.5 0 1 0 12 15.5A3.5 3.5 0 1 0 12 8.5ZM19.4 15A1 1 0 0 0 19.6 16.1L19.7 16.2A1.2 1.2 0 0 1 18 17.9L17.9 17.8A1 1 0 0 0 16.8 17.6A1 1 0 0 0 16.2 18.5V18.8A1.2 1.2 0 0 1 13.8 18.8V18.7A1 1 0 0 0 13.2 17.8A1 1 0 0 0 12.1 17.9L12 18A1.2 1.2 0 0 1 10.3 16.3L10.4 16.2A1 1 0 0 0 10.6 15.1A1 1 0 0 0 9.7 14.5H9.4A1.2 1.2 0 0 1 9.4 12.1H9.5A1 1 0 0 0 10.4 11.5A1 1 0 0 0 10.2 10.4L10.1 10.3A1.2 1.2 0 0 1 11.8 8.6L11.9 8.7A1 1 0 0 0 13 8.9A1 1 0 0 0 13.6 8V7.7A1.2 1.2 0 0 1 16 7.7V7.8A1 1 0 0 0 16.6 8.7A1 1 0 0 0 17.7 8.5L17.8 8.4A1.2 1.2 0 0 1 19.5 10.1L19.4 10.2A1 1 0 0 0 19.2 11.3A1 1 0 0 0 20.1 11.9H20.4A1.2 1.2 0 0 1 20.4 14.3H20.3A1 1 0 0 0 19.4 15Z',
 }
 
 export function GameTabBar(props: GameTabBarProps) {
   const { t } = useGame()
+  const tabs = () => [...inGameRoutes, 'settings'] as const
 
   return (
     <nav
@@ -22,22 +33,45 @@ export function GameTabBar(props: GameTabBarProps) {
         'p-2 shadow-[0_22px_60px_rgba(0,0,0,0.24)] backdrop-blur-xl',
       )}
     >
-      <div class="grid grid-cols-4 gap-2">
-        <For each={inGameRoutes}>
+      <div class="grid grid-cols-5 gap-2">
+        <For each={tabs()}>
           {(route) => (
             <button
               type="button"
               class={clsx(
-                'rounded-[1.2rem] px-3 py-3',
-                'text-xs font-medium transition-colors',
-                props.activeRoute === route
+                'flex min-h-16 flex-col items-center justify-center gap-1 rounded-[1.2rem] px-2 py-2',
+                'text-[11px] font-medium transition-colors',
+                route !== 'settings' && props.activeRoute === route
                   ? 'bg-(--color-accent) text-slate-950'
                   : 'bg-black/10 text-(--color-fg)',
               )}
-              aria-current={props.activeRoute === route ? 'page' : undefined}
-              onClick={() => props.onNavigate(route)}
+              aria-current={route !== 'settings' && props.activeRoute === route ? 'page' : undefined}
+              aria-label={route === 'settings' ? t('settings.open') : t(`nav.${route}`)}
+              onClick={() => {
+                if (route === 'settings') {
+                  props.onOpenSettings()
+                  return
+                }
+
+                props.onNavigate(route)
+              }}
             >
-              {t(`nav.${route}`)}
+              <svg
+                aria-hidden="true"
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d={tabIcons[route]}
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.8"
+                />
+              </svg>
+              <span>{route === 'settings' ? t('nav.settings') : t(`nav.${route}`)}</span>
             </button>
           )}
         </For>

--- a/src/features/landing/LandingScreen.tsx
+++ b/src/features/landing/LandingScreen.tsx
@@ -1,9 +1,14 @@
 import clsx from 'clsx'
+import { Show } from 'solid-js'
 import { BrandLogo } from '@/shared/BrandLogo'
 import { useGame } from '@/state/game-context'
 
-export function LandingScreen() {
-  const { startGame, t } = useGame()
+type LandingScreenProps = {
+  onEnterGame: () => void
+}
+
+export function LandingScreen(props: LandingScreenProps) {
+  const { startGame, state, t } = useGame()
 
   return (
     <section class="flex min-h-screen items-center py-6">
@@ -55,10 +60,16 @@ export function LandingScreen() {
               'transition-transform duration-200 ease-out',
               'motion-safe:hover:-translate-y-0.5',
             )}
-            onClick={() => startGame()}
+            onClick={() => {
+              startGame()
+              props.onEnterGame()
+            }}
           >
-            {t('landing.start')}
+            {state.hasStartedGame ? t('landing.continue') : t('landing.start')}
           </button>
+          <Show when={state.hasStartedGame}>
+            <p class="text-sm text-(--color-muted)">{t('landing.resumeHint')}</p>
+          </Show>
           <p class="text-sm text-(--color-muted)">{t('landing.caption')}</p>
         </div>
       </div>

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -8,6 +8,7 @@ const themeModes: ThemeMode[] = ['system', 'light', 'dark']
 type SettingsDialogProps = {
   isOpen: boolean
   onClose: () => void
+  onShowLanding: () => void
 }
 
 export function SettingsDialog(props: SettingsDialogProps) {
@@ -101,6 +102,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
                 </For>
               </div>
             </div>
+
+            <button
+              type="button"
+              class="rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-(--color-fg)"
+              onClick={() => {
+                props.onClose()
+                props.onShowLanding()
+              }}
+            >
+              {t('settings.showLanding')}
+            </button>
 
             <button
               type="button"

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -14,7 +14,9 @@ const dictionaries = {
       subtitle:
         'Start a new table-ready score session, keep round history locally, and switch language or theme any time.',
       start: 'Start scoring',
+      continue: 'Continue game',
       caption: 'Your game stays in this browser until you reset it.',
+      resumeHint: 'You can revisit this intro any time from the bottom dock settings.',
       featureFastTitle: 'Fast round entry',
       featureFastBody: 'Track Tichu calls, first-out, and team card points without breaking table flow.',
       featureLocalTitle: 'Local persistence',
@@ -44,6 +46,7 @@ const dictionaries = {
       round: 'Round',
       results: 'Results',
       history: 'History',
+      settings: 'Settings',
     },
     seats: {
       north: 'North',
@@ -103,6 +106,7 @@ const dictionaries = {
       system: 'System',
       light: 'Light',
       dark: 'Dark',
+      showLanding: 'Show Start Screen',
       reset: 'Reset Game',
       resetConfirm: 'Reset the saved game state?',
     },
@@ -131,7 +135,9 @@ const dictionaries = {
       subtitle:
         '새 점수 세션을 시작하고, 라운드 기록을 로컬에 유지하며, 언어와 테마를 언제든 바꿀 수 있습니다.',
       start: '시작하기',
+      continue: '게임 계속하기',
       caption: '게임 데이터는 초기화 전까지 이 브라우저에 유지됩니다.',
+      resumeHint: '하단 독의 설정에서 이 시작 화면을 다시 볼 수 있습니다.',
       featureFastTitle: '빠른 라운드 입력',
       featureFastBody: '티츄 콜, 첫 아웃, 팀 카드 점수를 끊김 없이 기록할 수 있습니다.',
       featureLocalTitle: '로컬 저장',
@@ -161,6 +167,7 @@ const dictionaries = {
       round: '라운드',
       results: '결과',
       history: '히스토리',
+      settings: '설정',
     },
     seats: {
       north: '북',
@@ -220,6 +227,7 @@ const dictionaries = {
       system: '시스템',
       light: '라이트',
       dark: '다크',
+      showLanding: '시작 화면 보기',
       reset: '게임 초기화',
       resetConfirm: '저장된 게임 상태를 초기화할까요?',
     },


### PR DESCRIPTION
## Summary
- move settings into the bottom dock and switch dock actions to icon-first controls
- stop the app title chrome from floating while scrolling
- allow the landing screen to be revisited and continue an existing game from there

Closes #27
Closes #28

## Validation
- pnpm lint
- pnpm test
- pnpm build