### PR TITLE
feat: add floating score summary sharing

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,4 +67,21 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: /party setup/i })).toBeInTheDocument()
     expect(window.location.hash).toBe('#/party')
   })
+
+  it('shows the floating score summary after the first round is saved', async () => {
+    seedStartedGameState('round')
+    render(() => <App />)
+
+    await fireEvent.input(screen.getByTestId('card-points-north-south'), {
+      target: { value: '60' },
+    })
+    await fireEvent.input(screen.getByTestId('card-points-east-west'), {
+      target: { value: '40' },
+    })
+    await fireEvent.click(screen.getAllByRole('radio', { name: /first out/i })[0]!)
+    await fireEvent.click(screen.getByTestId('save-round'))
+
+    expect(screen.getByTestId('global-score-summary')).toBeInTheDocument()
+    expect(screen.getAllByTestId('share-score-summary').length).toBeGreaterThan(0)
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { ApplicationControlBar } from '@/features/app/ApplicationControlBar'
 import { GameTabBar } from '@/features/app/GameTabBar'
 import { GameplayPages } from '@/features/app/GameplayPages'
 import { LandingScreen } from '@/features/landing/LandingScreen'
+import { GlobalScoreSummary } from '@/features/scoreboard/Scoreboard'
 import { SettingsDialog } from '@/features/settings/SettingsDialog'
 import { GameProvider, useGame } from '@/state/game-context'
 import {
@@ -109,6 +110,7 @@ function AppContent() {
           fallback={<LandingScreen onEnterGame={() => navigate(getDefaultRoute(true))} />}
         >
           <ApplicationControlBar />
+          <GlobalScoreSummary />
 
           <div class="min-h-[calc(100vh-15rem)]" data-testid={`page-${route()}`}>
             <GameplayPages

--- a/src/features/scoreboard/Scoreboard.tsx
+++ b/src/features/scoreboard/Scoreboard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { For, Show } from 'solid-js'
+import { For, Show, createSignal } from 'solid-js'
 import type { TeamId } from '@/domain/types'
 import { useGame } from '@/state/game-context'
 
@@ -13,6 +13,44 @@ export function Scoreboard(props: ScoreboardProps) {
       <ResultsSummary />
       <HistoryPanel onEditRound={props.onEditRound} />
     </section>
+  )
+}
+
+export function GlobalScoreSummary() {
+  const { cumulativeScores, leadingTeamId, state, teamNames, t } = useGame()
+
+  return (
+    <Show when={state.rounds.length > 0}>
+      <section
+        class="sticky top-4 z-10 rounded-[1.8rem] border border-white/10 bg-[color-mix(in_srgb,var(--color-surface)_90%,transparent)] p-3 shadow-[0_20px_60px_rgba(0,0,0,0.2)] backdrop-blur-xl"
+        data-testid="global-score-summary"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-[11px] uppercase tracking-[0.24em] text-(--color-accent)">
+              {t('scoreboard.floatingLabel')}
+            </p>
+            <p class="mt-1 text-xs text-(--color-muted)">
+              {state.rounds.length} {t('scoreboard.rounds')}
+            </p>
+          </div>
+          <ShareScoreButton />
+        </div>
+
+        <div class="mt-3 grid grid-cols-2 gap-2">
+          <CompactScoreCard
+            label={teamNames()['north-south']}
+            total={cumulativeScores()['north-south']}
+            isLeading={leadingTeamId() === 'north-south'}
+          />
+          <CompactScoreCard
+            label={teamNames()['east-west']}
+            total={cumulativeScores()['east-west']}
+            isLeading={leadingTeamId() === 'east-west'}
+          />
+        </div>
+      </section>
+    </Show>
   )
 }
 
@@ -41,12 +79,15 @@ export function ResultsSummary() {
 
       <section class="rounded-4xl border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
         <div class="flex items-center justify-between">
-          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
-            {t('sections.scoreboard')}
-          </p>
-          <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-(--color-muted)">
-            {state.rounds.length} {t('scoreboard.rounds')}
-          </span>
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
+              {t('sections.scoreboard')}
+            </p>
+            <span class="mt-2 inline-flex rounded-full border border-white/10 px-3 py-1 text-xs text-(--color-muted)">
+              {state.rounds.length} {t('scoreboard.rounds')}
+            </span>
+          </div>
+          <ShareScoreButton />
         </div>
 
         <div class="mt-5 grid gap-3">
@@ -195,4 +236,120 @@ function ActionButton(props: { children: string; onClick: () => void }) {
       {props.children}
     </button>
   )
+}
+
+function CompactScoreCard(props: { label: string; total: number; isLeading: boolean }) {
+  return (
+    <article
+      class={clsx(
+        'rounded-3xl border p-3',
+        props.isLeading ? 'border-amber-300/35 bg-amber-300/10' : 'border-white/10 bg-black/10',
+      )}
+    >
+      <p class="truncate text-[11px] uppercase tracking-[0.22em] text-(--color-muted)">{props.label}</p>
+      <p class="mt-2 text-2xl font-semibold text-(--color-fg)">{props.total}</p>
+    </article>
+  )
+}
+
+function ShareScoreButton() {
+  const { cumulativeScores, state, t, teamNames } = useGame()
+  const [statusMessage, setStatusMessage] = createSignal('')
+
+  const handleShare = async () => {
+    const svgMarkup = createScoreSummarySvg({
+      title: t('app.title'),
+      subtitle: t('scoreboard.shareSubtitle'),
+      roundsLabel: `${state.rounds.length} ${t('scoreboard.rounds')}`,
+      northSouthLabel: teamNames()['north-south'],
+      eastWestLabel: teamNames()['east-west'],
+      northSouthScore: cumulativeScores()['north-south'],
+      eastWestScore: cumulativeScores()['east-west'],
+    })
+    const file = new File([svgMarkup], 'tichuboard-score-summary.svg', { type: 'image/svg+xml' })
+
+    if (
+      typeof navigator !== 'undefined' &&
+      'share' in navigator &&
+      typeof navigator.share === 'function' &&
+      'canShare' in navigator &&
+      typeof navigator.canShare === 'function' &&
+      navigator.canShare({ files: [file] })
+    ) {
+      await navigator.share({
+        title: t('app.title'),
+        text: t('scoreboard.shareSubtitle'),
+        files: [file],
+      })
+      setStatusMessage(t('scoreboard.shareReady'))
+      return
+    }
+
+    const objectUrl = URL.createObjectURL(file)
+    const link = document.createElement('a')
+
+    link.href = objectUrl
+    link.download = file.name
+    link.click()
+    URL.revokeObjectURL(objectUrl)
+    setStatusMessage(t('scoreboard.shareDownloaded'))
+  }
+
+  return (
+    <div class="grid justify-items-end gap-2">
+      <button
+        type="button"
+        class="rounded-full border border-white/10 bg-black/15 px-3 py-2 text-xs text-(--color-fg)"
+        data-testid="share-score-summary"
+        onClick={() => void handleShare()}
+      >
+        {t('scoreboard.share')}
+      </button>
+      <Show when={statusMessage()}>
+        <p class="text-[11px] text-(--color-muted)">{statusMessage()}</p>
+      </Show>
+    </div>
+  )
+}
+
+function createScoreSummarySvg({
+  title,
+  subtitle,
+  roundsLabel,
+  northSouthLabel,
+  eastWestLabel,
+  northSouthScore,
+  eastWestScore,
+}: {
+  title: string
+  subtitle: string
+  roundsLabel: string
+  northSouthLabel: string
+  eastWestLabel: string
+  northSouthScore: number
+  eastWestScore: number
+}) {
+  const escape = (value: string) =>
+    value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${escape(title)}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#12213d" />
+      <stop offset="100%" stop-color="#0b1323" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="32" fill="url(#bg)" />
+  <rect x="48" y="48" width="1104" height="534" rx="32" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.14)" />
+  <text x="84" y="126" fill="#ffbf69" font-family="Space Grotesk, sans-serif" font-size="24" letter-spacing="4">TICHUBOARD</text>
+  <text x="84" y="184" fill="#f5efe5" font-family="Space Grotesk, sans-serif" font-size="56" font-weight="700">${escape(subtitle)}</text>
+  <text x="84" y="226" fill="#c5c0b5" font-family="Space Grotesk, sans-serif" font-size="24">${escape(roundsLabel)}</text>
+  <rect x="84" y="292" width="486" height="214" rx="28" fill="rgba(255,191,105,0.12)" stroke="rgba(255,191,105,0.24)" />
+  <rect x="630" y="292" width="486" height="214" rx="28" fill="rgba(125,211,252,0.12)" stroke="rgba(125,211,252,0.24)" />
+  <text x="118" y="360" fill="#c5c0b5" font-family="Space Grotesk, sans-serif" font-size="22">${escape(northSouthLabel)}</text>
+  <text x="118" y="446" fill="#f5efe5" font-family="Space Grotesk, sans-serif" font-size="92" font-weight="700">${northSouthScore}</text>
+  <text x="664" y="360" fill="#c5c0b5" font-family="Space Grotesk, sans-serif" font-size="22">${escape(eastWestLabel)}</text>
+  <text x="664" y="446" fill="#f5efe5" font-family="Space Grotesk, sans-serif" font-size="92" font-weight="700">${eastWestScore}</text>
+</svg>`
 }

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -101,6 +101,7 @@ const dictionaries = {
     scoreboard: {
       total: 'Total',
       rounds: 'Rounds',
+      floatingLabel: 'Live score summary',
       empty: 'No rounds yet. Enter the first round to start the scoreboard.',
       history: 'Round History',
       roundLabel: 'Round {{ round }}',
@@ -110,6 +111,10 @@ const dictionaries = {
       cardPoints: 'Card points',
       bonuses: 'Tichu bonuses',
       leading: 'Leading',
+      share: 'Share snapshot',
+      shareSubtitle: 'Current score summary',
+      shareReady: 'Share sheet opened.',
+      shareDownloaded: 'Score summary downloaded.',
     },
     settings: {
       language: 'Language',
@@ -237,6 +242,7 @@ const dictionaries = {
     scoreboard: {
       total: '총점',
       rounds: '라운드',
+      floatingLabel: '실시간 점수 요약',
       empty: '아직 라운드가 없습니다. 첫 라운드를 입력해 주세요.',
       history: '라운드 기록',
       roundLabel: '{{ round }}라운드',
@@ -246,6 +252,10 @@ const dictionaries = {
       cardPoints: '카드 점수',
       bonuses: '티츄 보너스',
       leading: '선두',
+      share: '요약 공유',
+      shareSubtitle: '현재 점수 요약',
+      shareReady: '공유 시트를 열었습니다.',
+      shareDownloaded: '점수 요약 파일을 내려받았습니다.',
     },
     settings: {
       language: '언어',


### PR DESCRIPTION
## Summary
- add a floating global score summary after the first saved round
- improve results summary actions with snapshot sharing support
- add tests covering the global summary after round save

Closes #30

## Validation
- pnpm lint
- pnpm test
- pnpm build