### PR TITLE
feat: add editable party team names

### DIFF
--- a/src/domain/defaults.ts
+++ b/src/domain/defaults.ts
@@ -131,6 +131,7 @@ export function createDefaultSettings(): GameSettings {
     language: 'en',
     theme: 'system',
     teamColors: createDefaultTeamColors(),
+    teamNames: createDefaultTeamNames('en'),
   }
 }
 
@@ -139,6 +140,18 @@ export function createDefaultTeamColors(): Record<TeamId, TeamColor> {
     'north-south': 'amber',
     'east-west': 'sky',
   }
+}
+
+export function createDefaultTeamNames(language: Language): Record<TeamId, string> {
+  return language === 'ko'
+    ? {
+        'north-south': '1팀',
+        'east-west': '2팀',
+      }
+    : {
+        'north-south': 'Team 1',
+        'east-west': 'Team 2',
+      }
 }
 
 export function mergeRecentPlayerNames(existingNames: string[], nextNames: string[]) {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -78,6 +78,7 @@ export type GameSettings = {
   language: Language
   theme: ThemeMode
   teamColors: Record<TeamId, TeamColor>
+  teamNames: Record<TeamId, string>
 }
 
 export type PersistedGameState = {

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -10,7 +10,7 @@ describe('PartySetup', () => {
 
     if (value) {
       const nextState = JSON.parse(value) as { recentPlayerNames: string[] }
-      nextState.recentPlayerNames = ['Morgan']
+      nextState.recentPlayerNames = ['Morgan', 'Nova']
       localStorage.setItem('tichu-board-r1:v1', JSON.stringify(nextState))
     }
   })
@@ -20,7 +20,9 @@ describe('PartySetup', () => {
 
     const northSeat = screen.getByTestId('seat-north')
     await fireEvent.click(northSeat)
-    await fireEvent.input(screen.getByRole('textbox'), { target: { value: 'Alice' } })
+    await fireEvent.input(within(screen.getByTestId('party-editor-dialog')).getByRole('textbox'), {
+      target: { value: 'Alice' },
+    })
     await fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
 
     expect(within(screen.getByTestId('seat-north')).getByText('Alice')).toBeInTheDocument()
@@ -32,16 +34,28 @@ describe('PartySetup', () => {
     expect(within(screen.getByTestId('seat-east')).getByText('Alice')).toBeInTheDocument()
   })
 
-  it('can reroll a unique name, disable used team colors, and block duplicate names', async () => {
+  it('can rename teams, reroll a unique name, disable used team colors, and block duplicate names', async () => {
     render(() => <App />)
+
+    await fireEvent.input(screen.getByTestId('team-label-north-south'), {
+      target: { value: 'Alpha Team' },
+    })
+
+    expect(screen.getByTestId('team-label-north-south')).toHaveValue('Alpha Team')
+    expect(screen.getByTestId('bench-recent-Morgan')).toBeInTheDocument()
+    expect(screen.getByTestId('bench-recent-Nova')).toBeInTheDocument()
 
     const northSeat = screen.getByTestId('seat-north')
     await fireEvent.click(northSeat)
 
-    const northNameBefore = (screen.getByRole('textbox') as HTMLInputElement).value
+    const northNameBefore = (
+      within(screen.getByTestId('party-editor-dialog')).getByRole('textbox') as HTMLInputElement
+    ).value
     await fireEvent.click(screen.getByRole('button', { name: /reroll random name/i }))
 
-    const rerolledName = (screen.getByRole('textbox') as HTMLInputElement).value
+    const rerolledName = (
+      within(screen.getByTestId('party-editor-dialog')).getByRole('textbox') as HTMLInputElement
+    ).value
     expect(rerolledName).not.toBe(northNameBefore)
 
     await fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
@@ -54,7 +68,9 @@ describe('PartySetup', () => {
     expect(screen.getByTestId('team-color-north-south-amber')).toHaveAttribute('aria-pressed', 'true')
 
     await fireEvent.click(screen.getByTestId('seat-east'))
-    await fireEvent.input(screen.getByRole('textbox'), { target: { value: rerolledName } })
+    await fireEvent.input(within(screen.getByTestId('party-editor-dialog')).getByRole('textbox'), {
+      target: { value: rerolledName },
+    })
     await fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
 
     expect(screen.getByText(/player names must be unique/i)).toBeInTheDocument()

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -46,7 +46,7 @@ type EditorDraft = {
 }
 
 export function PartySetup() {
-  const { assignPlayerSeat, setTeamColor, state, teamNames, updatePlayerName, t } = useGame()
+  const { assignPlayerSeat, setTeamColor, setTeamName, state, teamLineups, teamNames, updatePlayerName, t } = useGame()
   const [editorDraft, setEditorDraft] = createSignal<EditorDraft | null>(null)
   const [errorMessage, setErrorMessage] = createSignal('')
   const [armedPlayerId, setArmedPlayerId] = createSignal<PlayerId | null>(null)
@@ -79,7 +79,7 @@ export function PartySetup() {
 
     return state.recentPlayerNames
       .filter((name) => !seatedNames.has(name.trim().toLowerCase()))
-      .slice(0, 5)
+      .slice(0, 2)
   })
 
   const interactionHint = createMemo(() => {
@@ -216,16 +216,18 @@ export function PartySetup() {
           <TeamSetupCard
             teamId="north-south"
             label={teamNames()['north-south']}
-            subtitle={t('teams.northSouth')}
+            subtitle={teamLineups()['north-south']}
             selectedColor={state.settings.teamColors['north-south']}
             onSelectColor={setTeamColor}
+            onNameChange={setTeamName}
           />
           <TeamSetupCard
             teamId="east-west"
             label={teamNames()['east-west']}
-            subtitle={t('teams.eastWest')}
+            subtitle={teamLineups()['east-west']}
             selectedColor={state.settings.teamColors['east-west']}
             onSelectColor={setTeamColor}
+            onNameChange={setTeamName}
           />
         </div>
       </div>
@@ -292,9 +294,9 @@ export function PartySetup() {
                   <button
                     type="button"
                     class={clsx(
-                      'rounded-full border px-3 py-2 text-sm transition-colors',
+                      'rounded-full border px-3 py-2 text-sm transition-colors opacity-55 grayscale',
                       armedRecentName() === name
-                        ? 'border-(--color-accent) bg-(--color-accent) text-slate-950'
+                        ? 'border-(--color-accent) bg-(--color-accent) text-slate-950 opacity-100 grayscale-0'
                         : 'border-white/10 bg-black/15 text-(--color-fg)',
                     )}
                     draggable="true"
@@ -529,6 +531,7 @@ function TeamSetupCard(props: {
   subtitle: string
   selectedColor: TeamColor
   onSelectColor: (teamId: TeamId, color: TeamColor) => void
+  onNameChange: (teamId: TeamId, name: string) => void
 }) {
   const { state, t } = useGame()
   const oppositeTeamId = () => (props.teamId === 'north-south' ? 'east-west' : 'north-south')
@@ -538,10 +541,15 @@ function TeamSetupCard(props: {
       class="rounded-3xl border border-white/10 bg-black/10 p-3"
       data-testid={`team-name-${props.teamId}`}
     >
-      <div class="flex items-center justify-between gap-3">
+      <div class="grid gap-3">
         <div>
-          <p class="text-sm font-medium text-(--color-fg)">{props.label}</p>
-          <p class="mt-1 text-[11px] uppercase tracking-[0.18em] text-(--color-muted)">{props.subtitle}</p>
+          <input
+            class="w-full border-b border-dashed border-white/18 bg-transparent pb-1 text-sm font-medium text-(--color-fg) outline-none focus:border-(--color-accent)"
+            value={props.label}
+            data-testid={`team-label-${props.teamId}`}
+            onInput={(event) => props.onNameChange(props.teamId, event.currentTarget.value)}
+          />
+          <p class="mt-1 text-[11px] text-(--color-muted)">{props.subtitle}</p>
         </div>
         <div class="flex flex-wrap justify-end gap-1">
           <For each={teamColorOptions}>

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -8,7 +8,7 @@ import {
   type ParentComponent,
 } from 'solid-js'
 import { createStore, reconcile, unwrap } from 'solid-js/store'
-import { createDefaultPlayers, mergeRecentPlayerNames } from '@/domain/defaults'
+import { createDefaultPlayers, createDefaultTeamNames, mergeRecentPlayerNames } from '@/domain/defaults'
 import { getTeamIdBySeat } from '@/domain/helpers'
 import {
   calculateCumulativeScores,
@@ -41,6 +41,7 @@ type GameContextValue = {
   gameStatus: () => ReturnType<typeof getGameStatus>
   leadingTeamId: () => ReturnType<typeof getLeadingTeamId>
   teamNames: () => Record<TeamId, string>
+  teamLineups: () => Record<TeamId, string>
   systemTheme: () => Exclude<ThemeMode, 'system'>
   effectiveTheme: () => Exclude<ThemeMode, 'system'>
   t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
@@ -49,6 +50,7 @@ type GameContextValue = {
   assignPlayerSeat: (playerId: PlayerId, seat: Seat) => void
   swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
   setTeamColor: (teamId: TeamId, color: TeamColor) => void
+  setTeamName: (teamId: TeamId, name: string) => void
   setLanguage: (language: PersistedGameState['settings']['language']) => void
   setTheme: (theme: ThemeMode) => void
   addRound: (input: RoundInput) => void
@@ -73,7 +75,7 @@ export const GameProvider: ParentComponent = (props) => {
   )
   const gameStatus = createMemo(() => getGameStatus(cumulativeScores()))
   const leadingTeamId = createMemo(() => getLeadingTeamId(cumulativeScores()))
-  const teamNames = createMemo(() => {
+  const teamLineups = createMemo(() => {
     const names = {
       'north-south': [] as string[],
       'east-west': [] as string[],
@@ -88,6 +90,7 @@ export const GameProvider: ParentComponent = (props) => {
       'east-west': names['east-west'].join(' / '),
     }
   })
+  const teamNames = createMemo(() => state.settings.teamNames)
   const effectiveTheme = createMemo<Exclude<ThemeMode, 'system'>>(() =>
     state.settings.theme === 'system' ? systemTheme() : state.settings.theme,
   )
@@ -122,6 +125,7 @@ export const GameProvider: ParentComponent = (props) => {
     gameStatus,
     leadingTeamId,
     teamNames,
+    teamLineups,
     systemTheme,
     effectiveTheme,
     t: (key, args) => translate()(key, args),
@@ -200,7 +204,27 @@ export const GameProvider: ParentComponent = (props) => {
 
       setState('settings', 'teamColors', teamId, color)
     },
-    setLanguage: (language) => setState('settings', 'language', language),
+    setTeamName: (teamId, name) =>
+      setState('settings', 'teamNames', teamId, name.trim().slice(0, 24) || state.settings.teamNames[teamId]),
+    setLanguage: (language) => {
+      const previousDefaults = createDefaultTeamNames(state.settings.language)
+      const nextDefaults = createDefaultTeamNames(language)
+
+      setState('settings', (current) => ({
+        ...current,
+        language,
+        teamNames: {
+          'north-south':
+            current.teamNames['north-south'] === previousDefaults['north-south']
+              ? nextDefaults['north-south']
+              : current.teamNames['north-south'],
+          'east-west':
+            current.teamNames['east-west'] === previousDefaults['east-west']
+              ? nextDefaults['east-west']
+              : current.teamNames['east-west'],
+        },
+      }))
+    },
     setTheme: (theme) => setState('settings', 'theme', theme),
     startRound: () => {
       if (state.activeRoundStartedAt) {

--- a/src/storage/game-storage.ts
+++ b/src/storage/game-storage.ts
@@ -49,6 +49,12 @@ export function migratePersistedState(value: unknown): PersistedGameState | null
           ? ((value.settings as PersistedGameState['settings']).teamColors as PersistedGameState['settings']['teamColors'])
           : {}),
       },
+      teamNames: {
+        ...createDefaultSettings().teamNames,
+        ...(isRecord((value.settings as PersistedGameState['settings']).teamNames)
+          ? ((value.settings as PersistedGameState['settings']).teamNames as PersistedGameState['settings']['teamNames'])
+          : {}),
+      },
     },
   }
 }


### PR DESCRIPTION
## Summary
- add editable Team 1 and Team 2 names with locale-aware defaults
- persist custom team names and keep defaults in sync when language changes
- expand the party bench to show two recent inactive names and cover the flow with tests

Closes #51