### PR TITLE
refactor: split the party setup feature

### DIFF
--- a/src/features/party-setup/PartyBench.tsx
+++ b/src/features/party-setup/PartyBench.tsx
@@ -1,0 +1,108 @@
+import clsx from 'clsx'
+import { For, Show } from 'solid-js'
+import type { PlayerId, TeamColor } from '@/domain/types'
+import { teamColorClasses } from './party-setup.shared'
+
+type BenchPlayer = {
+  id: PlayerId
+  name: string
+  seatInitial: string
+  teamColor: TeamColor
+}
+
+type PartyBenchProps = {
+  players: BenchPlayer[]
+  recentNames: string[]
+  armedPlayerId: PlayerId | null
+  armedRecentName: string | null
+  onArmPlayer: (playerId: PlayerId) => void
+  onDragPlayerStart: (playerId: PlayerId) => void
+  onDragPlayerEnd: () => void
+  onRecentNameClick: (name: string) => void
+  onRecentNameDragStart: (name: string) => void
+  onRecentNameDragEnd: () => void
+  onClearSelection: () => void
+  title: string
+  hint: string
+  clearLabel: string
+}
+
+export function PartyBench(props: PartyBenchProps) {
+  return (
+    <section class="grid gap-3 rounded-4xl border border-white/10 bg-black/12 p-3">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="text-[11px] uppercase tracking-[0.22em] text-(--color-accent)">{props.title}</p>
+          <p class="mt-1 text-[11px] text-(--color-muted)">{props.hint}</p>
+        </div>
+        <Show when={props.armedPlayerId || props.armedRecentName}>
+          <button
+            type="button"
+            class="rounded-full border border-white/10 px-3 py-1 text-[11px] text-(--color-fg)"
+            onClick={() => props.onClearSelection()}
+          >
+            {props.clearLabel}
+          </button>
+        </Show>
+      </div>
+
+      <div class="grid gap-2">
+        <div class="flex flex-wrap gap-2">
+          <For each={props.players}>
+            {(player) => (
+              <button
+                type="button"
+                class={clsx(
+                  'inline-flex min-h-12 items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-transform',
+                  props.armedPlayerId === player.id
+                    ? 'border-(--color-accent) bg-(--color-accent) text-slate-950'
+                    : 'border-white/10 bg-(--color-surface) text-(--color-fg) motion-safe:hover:-translate-y-0.5',
+                )}
+                draggable="true"
+                data-testid={`bench-player-${player.id}`}
+                onClick={() => props.onArmPlayer(player.id)}
+                onDragStart={() => props.onDragPlayerStart(player.id)}
+                onDragEnd={props.onDragPlayerEnd}
+              >
+                <span
+                  class={clsx(
+                    'inline-flex h-8 w-8 items-center justify-center rounded-full text-[11px] font-semibold',
+                    teamColorClasses[player.teamColor].chip,
+                  )}
+                >
+                  {player.seatInitial}
+                </span>
+                <span class="font-medium">{player.name}</span>
+              </button>
+            )}
+          </For>
+        </div>
+
+        <Show when={props.recentNames.length > 0}>
+          <div class="flex flex-wrap gap-2 border-t border-white/8 pt-2">
+            <For each={props.recentNames}>
+              {(name) => (
+                <button
+                  type="button"
+                  class={clsx(
+                    'rounded-full border px-3 py-2 text-sm transition-colors opacity-55 grayscale',
+                    props.armedRecentName === name
+                      ? 'border-(--color-accent) bg-(--color-accent) text-slate-950 opacity-100 grayscale-0'
+                      : 'border-white/10 bg-black/15 text-(--color-fg)',
+                  )}
+                  draggable="true"
+                  data-testid={`bench-recent-${name}`}
+                  onClick={() => props.onRecentNameClick(name)}
+                  onDragStart={() => props.onRecentNameDragStart(name)}
+                  onDragEnd={props.onRecentNameDragEnd}
+                >
+                  {name}
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </section>
+  )
+}

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -1,80 +1,16 @@
-import clsx from 'clsx'
-import { For, Show, createMemo, createSignal, type ParentProps } from 'solid-js'
-import { getRandomPlayerName } from '@/domain/defaults'
-import type { Language, Player, PlayerId, Seat, TeamColor, TeamId } from '@/domain/types'
+import { Show, createMemo, createSignal } from 'solid-js'
+import type { PlayerId, Seat, TeamId } from '@/domain/types'
 import { useGame } from '@/state/game-context'
-
-const teamColorClasses: Record<TeamColor, { chip: string; ring: string; surface: string; glow: string }> = {
-  amber: {
-    chip: 'bg-amber-300 text-amber-950',
-    ring: 'ring-amber-300/55',
-    surface: 'from-amber-300/18 to-amber-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(252,211,77,0.24),0_18px_50px_rgba(252,211,77,0.14)]',
-  },
-  emerald: {
-    chip: 'bg-emerald-300 text-emerald-950',
-    ring: 'ring-emerald-300/55',
-    surface: 'from-emerald-300/18 to-emerald-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(110,231,183,0.24),0_18px_50px_rgba(110,231,183,0.14)]',
-  },
-  sky: {
-    chip: 'bg-sky-300 text-sky-950',
-    ring: 'ring-sky-300/55',
-    surface: 'from-sky-300/18 to-sky-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(125,211,252,0.24),0_18px_50px_rgba(125,211,252,0.14)]',
-  },
-  rose: {
-    chip: 'bg-rose-300 text-rose-950',
-    ring: 'ring-rose-300/55',
-    surface: 'from-rose-300/18 to-rose-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(253,164,175,0.24),0_18px_50px_rgba(253,164,175,0.14)]',
-  },
-  violet: {
-    chip: 'bg-violet-300 text-violet-950',
-    ring: 'ring-violet-300/55',
-    surface: 'from-violet-300/18 to-violet-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(196,181,253,0.24),0_18px_50px_rgba(196,181,253,0.14)]',
-  },
-  teal: {
-    chip: 'bg-teal-300 text-teal-950',
-    ring: 'ring-teal-300/55',
-    surface: 'from-teal-300/18 to-teal-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(94,234,212,0.24),0_18px_50px_rgba(94,234,212,0.14)]',
-  },
-  orange: {
-    chip: 'bg-orange-300 text-orange-950',
-    ring: 'ring-orange-300/55',
-    surface: 'from-orange-300/18 to-orange-100/4',
-    glow: 'shadow-[0_0_0_1px_rgba(253,186,116,0.24),0_18px_50px_rgba(253,186,116,0.14)]',
-  },
-}
-
-const teamColorOptions: TeamColor[] = ['amber', 'sky', 'emerald', 'rose', 'violet', 'teal', 'orange']
-
-const seatLayouts: { seat: Seat; className: string }[] = [
-  { seat: 'north', className: 'col-start-2 row-start-1' },
-  { seat: 'west', className: 'col-start-1 row-start-2' },
-  { seat: 'east', className: 'col-start-3 row-start-2' },
-  { seat: 'south', className: 'col-start-2 row-start-3' },
-]
-
-const seatOverlayLabels: Record<Seat, string> = {
-  north: 'N',
-  west: 'W',
-  east: 'E',
-  south: 'S',
-}
-
-type EditorDraft = {
-  playerId: PlayerId
-  name: string
-}
-
-type TeamEditorDraft = {
-  teamId: TeamId
-  name: string
-  color: TeamColor
-}
+import { PartyBench } from './PartyBench'
+import { PlayerEditorDialog, TeamEditorDialog } from './PartySetupDialogs'
+import { createSeatEntries, SeatMapBoard } from './SeatMapBoard'
+import { TeamSetupCard } from './TeamSetupCard'
+import {
+  getTeamId,
+  getUniqueRandomName,
+  type EditorDraft,
+  type TeamEditorDraft,
+} from './party-setup.shared'
 
 export function PartySetup() {
   const { assignPlayerSeat, setTeamColor, setTeamName, state, teamLineups, teamNames, updatePlayerName, t } = useGame()
@@ -86,73 +22,61 @@ export function PartySetup() {
   const [armedRecentName, setArmedRecentName] = createSignal<string | null>(null)
   const [draggingRecentName, setDraggingRecentName] = createSignal<string | null>(null)
 
-  const playersBySeat = createMemo(() =>
-    seatLayouts.map(({ seat, className }) => ({
-      seat,
-      className,
-      player: state.players.find((item) => item.seat === seat) ?? null,
-    })),
-  )
-
+  const seatEntries = createMemo(() => createSeatEntries(state.players))
   const activePlayer = createMemo(() => {
     const draft = editorDraft()
     return draft ? state.players.find((player) => player.id === draft.playerId) ?? null : null
   })
-
-  const activeTeamEditor = createMemo(() => teamEditorDraft())
-
-  const rosterPlayers = createMemo(() =>
-    state.players.map((player) => ({
-      ...player,
-      teamId: getTeamId(player.seat),
-    })),
-  )
-
   const recentNames = createMemo(() => {
     const seatedNames = new Set(state.players.map((player) => player.name.trim().toLowerCase()))
-
-    return state.recentPlayerNames
-      .filter((name) => !seatedNames.has(name.trim().toLowerCase()))
-      .slice(0, 2)
+    return state.recentPlayerNames.filter((name) => !seatedNames.has(name.trim().toLowerCase())).slice(0, 2)
   })
-
+  const rosterPlayers = createMemo(() =>
+    state.players.map((player) => ({
+      id: player.id,
+      name: player.name,
+      seatInitial: t(`seats.${player.seat}`).slice(0, 1),
+      teamColor: state.settings.teamColors[getTeamId(player.seat)],
+    })),
+  )
   const interactionHint = createMemo(() => {
     if (armedRecentName()) {
       return t('party.pendingRecentName', { name: armedRecentName()! })
     }
-
     if (armedPlayerId()) {
       const player = state.players.find((item) => item.id === armedPlayerId())
       return player ? t('party.pendingSeatMove', { name: player.name }) : ''
     }
-
     return ''
   })
 
-  const openEditor = (player: Player) => {
-    setEditorDraft({
-      playerId: player.id,
-      name: player.name,
-    })
+  const openPlayerEditor = (playerId: PlayerId) => {
+    const player = state.players.find((item) => item.id === playerId)
+
+    if (!player) {
+      return
+    }
+    setEditorDraft({ playerId: player.id, name: player.name })
     setErrorMessage('')
   }
 
-  const closeEditor = () => {
+  const closePlayerEditor = () => {
     setEditorDraft(null)
     setErrorMessage('')
   }
 
   const openTeamEditor = (teamId: TeamId) => {
-    setTeamEditorDraft({
-      teamId,
-      name: teamNames()[teamId],
-      color: state.settings.teamColors[teamId],
-    })
+    setTeamEditorDraft({ teamId, name: teamNames()[teamId], color: state.settings.teamColors[teamId] })
   }
 
-  const closeTeamEditor = () => {
-    setTeamEditorDraft(null)
+  const clearArmedState = () => {
+    setArmedPlayerId(null)
+    setDraggingPlayerId(null)
+    setArmedRecentName(null)
+    setDraggingRecentName(null)
   }
+
+  const activeTeamId = (teamId: TeamId) => (teamId === 'north-south' ? 'east-west' : 'north-south')
 
   const applyNameToSeat = (playerId: PlayerId, nextName: string) => {
     const trimmedName = nextName.trim()
@@ -161,11 +85,9 @@ export function PartySetup() {
       setErrorMessage(t('party.validationEmptyName'))
       return false
     }
-
     const hasDuplicate = state.players.some(
       (player) => player.id !== playerId && player.name.trim().toLowerCase() === trimmedName.toLowerCase(),
     )
-
     if (hasDuplicate) {
       setErrorMessage(t('party.validationDuplicateName'))
       return false
@@ -176,69 +98,38 @@ export function PartySetup() {
     return true
   }
 
-  const clearArmedState = () => {
-    setArmedPlayerId(null)
-    setDraggingPlayerId(null)
-    setArmedRecentName(null)
-    setDraggingRecentName(null)
-  }
-
   const handleSeatAssign = (seat: Seat) => {
     const seatPlayer = state.players.find((player) => player.seat === seat)
 
     if (!seatPlayer) {
       return
     }
-
     if (draggingRecentName() || armedRecentName()) {
       const nextName = draggingRecentName() ?? armedRecentName()
-
       if (nextName && applyNameToSeat(seatPlayer.id, nextName)) {
         clearArmedState()
       }
-
       return
     }
-
     if (draggingPlayerId() || armedPlayerId()) {
       const sourcePlayerId = draggingPlayerId() ?? armedPlayerId()
-
       if (sourcePlayerId) {
         assignPlayerSeat(sourcePlayerId, seat)
         clearArmedState()
       }
-
       return
     }
-
-    openEditor(seatPlayer)
+    openPlayerEditor(seatPlayer.id)
   }
 
-  const applyRecentName = (name: string) => {
+  const commitPlayerEditor = () => {
     const draft = editorDraft()
 
-    if (draft) {
-      setEditorDraft({ ...draft, name })
-      setErrorMessage('')
+    if (!draft || !applyNameToSeat(draft.playerId, draft.name)) {
       return
     }
 
-    setArmedRecentName(name)
-    setArmedPlayerId(null)
-  }
-
-  const commitEditor = () => {
-    const draft = editorDraft()
-
-    if (!draft) {
-      return
-    }
-
-    if (!applyNameToSeat(draft.playerId, draft.name)) {
-      return
-    }
-
-    closeEditor()
+    closePlayerEditor()
   }
 
   const commitTeamEditor = () => {
@@ -250,7 +141,7 @@ export function PartySetup() {
 
     setTeamName(draft.teamId, draft.name)
     setTeamColor(draft.teamId, draft.color)
-    closeTeamEditor()
+    setTeamEditorDraft(null)
   }
 
   return (
@@ -258,9 +149,7 @@ export function PartySetup() {
       <div class="grid gap-3">
         <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
-              {t('sections.party')}
-            </p>
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{t('sections.party')}</p>
             <p class="mt-2 text-xs leading-5 text-(--color-muted) sm:text-sm">{t('party.hintCompact')}</p>
           </div>
           <Show when={interactionHint()}>
@@ -273,494 +162,124 @@ export function PartySetup() {
         <div class="grid gap-2 sm:grid-cols-2">
           <TeamSetupCard
             teamId="north-south"
-            label={() => teamNames()['north-south']}
-            subtitle={() => teamLineups()['north-south']}
-            selectedColor={() => state.settings.teamColors['north-south']}
-            oppositeColor={() => state.settings.teamColors['east-west']}
+            label={teamNames()['north-south']}
+            subtitle={teamLineups()['north-south']}
+            selectedColor={state.settings.teamColors['north-south']}
+            oppositeColor={state.settings.teamColors['east-west']}
+            editLabel={t('party.editTeam')}
             onOpenEditor={openTeamEditor}
           />
           <TeamSetupCard
             teamId="east-west"
-            label={() => teamNames()['east-west']}
-            subtitle={() => teamLineups()['east-west']}
-            selectedColor={() => state.settings.teamColors['east-west']}
-            oppositeColor={() => state.settings.teamColors['north-south']}
+            label={teamNames()['east-west']}
+            subtitle={teamLineups()['east-west']}
+            selectedColor={state.settings.teamColors['east-west']}
+            oppositeColor={state.settings.teamColors['north-south']}
+            editLabel={t('party.editTeam')}
             onOpenEditor={openTeamEditor}
           />
         </div>
       </div>
 
-      <section class="grid gap-3 rounded-4xl border border-white/10 bg-black/12 p-3">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <p class="text-[11px] uppercase tracking-[0.22em] text-(--color-accent)">{t('party.playerBench')}</p>
-            <p class="mt-1 text-[11px] text-(--color-muted)">{t('party.playerBenchHint')}</p>
-          </div>
-          <Show when={armedPlayerId() || armedRecentName()}>
-            <button
-              type="button"
-              class="rounded-full border border-white/10 px-3 py-1 text-[11px] text-(--color-fg)"
-              onClick={clearArmedState}
-            >
-              {t('party.clearSelection')}
-            </button>
-          </Show>
-        </div>
+      <PartyBench
+        players={rosterPlayers()}
+        recentNames={recentNames()}
+        armedPlayerId={armedPlayerId()}
+        armedRecentName={armedRecentName()}
+        onArmPlayer={(playerId) => {
+          setArmedPlayerId(playerId)
+          setArmedRecentName(null)
+        }}
+        onDragPlayerStart={(playerId) => {
+          setDraggingPlayerId(playerId)
+          setArmedRecentName(null)
+        }}
+        onDragPlayerEnd={() => setDraggingPlayerId(null)}
+        onRecentNameClick={(name) => {
+          const draft = editorDraft()
+          if (draft) {
+            setEditorDraft({ ...draft, name })
+            setErrorMessage('')
+            return
+          }
+          setArmedRecentName(name)
+          setArmedPlayerId(null)
+        }}
+        onRecentNameDragStart={(name) => {
+          setDraggingRecentName(name)
+          setArmedPlayerId(null)
+        }}
+        onRecentNameDragEnd={() => setDraggingRecentName(null)}
+        onClearSelection={clearArmedState}
+        title={t('party.playerBench')}
+        hint={t('party.playerBenchHint')}
+        clearLabel={t('party.clearSelection')}
+      />
 
-        <div class="grid gap-2">
-          <div class="flex flex-wrap gap-2">
-            <For each={rosterPlayers()}>
-              {(player) => (
-                <button
-                  type="button"
-                  class={clsx(
-                    'inline-flex min-h-12 items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-transform',
-                    armedPlayerId() === player.id
-                      ? 'border-(--color-accent) bg-(--color-accent) text-slate-950'
-                      : 'border-white/10 bg-(--color-surface) text-(--color-fg) motion-safe:hover:-translate-y-0.5',
-                  )}
-                  draggable="true"
-                  data-testid={`bench-player-${player.id}`}
-                  onClick={() => {
-                    setArmedPlayerId(player.id)
-                    setArmedRecentName(null)
-                  }}
-                  onDragStart={() => {
-                    setDraggingPlayerId(player.id)
-                    setArmedRecentName(null)
-                  }}
-                  onDragEnd={() => setDraggingPlayerId(null)}
-                >
-                  <span
-                    class={clsx(
-                      'inline-flex h-8 w-8 items-center justify-center rounded-full text-[11px] font-semibold',
-                      teamColorClasses[state.settings.teamColors[player.teamId]].chip,
-                    )}
-                  >
-                    {t(`seats.${player.seat}`).slice(0, 1)}
-                  </span>
-                  <span class="font-medium">{player.name}</span>
-                </button>
-              )}
-            </For>
-          </div>
-
-          <Show when={recentNames().length > 0}>
-            <div class="flex flex-wrap gap-2 border-t border-white/8 pt-2">
-              <For each={recentNames()}>
-                {(name) => (
-                  <button
-                    type="button"
-                    class={clsx(
-                      'rounded-full border px-3 py-2 text-sm transition-colors opacity-55 grayscale',
-                      armedRecentName() === name
-                        ? 'border-(--color-accent) bg-(--color-accent) text-slate-950 opacity-100 grayscale-0'
-                        : 'border-white/10 bg-black/15 text-(--color-fg)',
-                    )}
-                    draggable="true"
-                    data-testid={`bench-recent-${name}`}
-                    onClick={() => applyRecentName(name)}
-                    onDragStart={() => {
-                      setDraggingRecentName(name)
-                      setArmedPlayerId(null)
-                    }}
-                    onDragEnd={() => setDraggingRecentName(null)}
-                  >
-                    {name}
-                  </button>
-                )}
-              </For>
-            </div>
-          </Show>
-        </div>
-      </section>
-
-      <div
-        class="grid min-h-96 grid-cols-[minmax(0,1fr)_4.5rem_minmax(0,1fr)] grid-rows-[auto_minmax(6rem,1fr)_auto] gap-3"
-        aria-label={t('party.tableLabel')}
-      >
-        <div class="col-start-2 row-start-2 flex items-center justify-center">
-          <div class="flex h-full w-full items-center justify-center rounded-4xl border border-white/10 bg-[radial-gradient(circle_at_top,rgba(255,191,105,0.18),rgba(15,23,42,0.94))] p-4 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
-            <div class="grid place-items-center gap-2">
-              <div class="h-12 w-12 rounded-full border border-white/12 bg-black/18 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]" />
-              <p class="text-[10px] uppercase tracking-[0.3em] text-(--color-muted)">Tichu</p>
-            </div>
-          </div>
-        </div>
-
-        <For each={playersBySeat()}>
-          {(entry) => {
-            const player = entry.player
-            const teamId = player ? getTeamId(player.seat) : getTeamId(entry.seat)
-            const colors = teamColorClasses[state.settings.teamColors[teamId]]
-            const isActiveDropTarget = Boolean(armedPlayerId() || draggingPlayerId() || armedRecentName() || draggingRecentName())
-
-            return (
-              <button
-                type="button"
-                class={clsx(
-                  entry.className,
-                  'relative flex min-h-28 flex-col justify-between overflow-hidden rounded-3xl border border-white/10 bg-(--color-surface) p-3 text-left',
-                  'ring-1 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5',
-                  colors.ring,
-                  colors.glow,
-                  isActiveDropTarget && 'border-dashed border-(--color-accent)',
-                )}
-                aria-label={t('party.seatAction', {
-                  seat: t(`seats.${entry.seat}`),
-                  name: player?.name ?? '',
-                })}
-                onClick={() => handleSeatAssign(entry.seat)}
-                onDragOver={(event) => event.preventDefault()}
-                onDrop={() => handleSeatAssign(entry.seat)}
-                data-testid={`seat-${entry.seat}`}
-              >
-                <div
-                  class={clsx(
-                    'pointer-events-none absolute inset-0 bg-linear-to-br opacity-70',
-                    colors.surface,
-                  )}
-                />
-                <span
-                  class="pointer-events-none absolute inset-0 flex items-center justify-center text-[clamp(3.5rem,20vw,5.25rem)] font-black tracking-[-0.08em] text-white/6"
-                  aria-hidden="true"
-                  data-testid={`seat-overlay-${entry.seat}`}
-                >
-                  {seatOverlayLabels[entry.seat]}
-                </span>
-                <div class="relative flex items-start justify-between gap-2">
-                  <span class="inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/18 px-2 py-1 text-[10px] text-(--color-muted)">
-                    <TeamBadge teamId={teamId} />
-                    {teamId === 'north-south' ? teamNames()['north-south'] : teamNames()['east-west']}
-                  </span>
-                </div>
-
-                <div class="relative grid gap-1">
-                  <p class="text-lg font-semibold tracking-[-0.02em] text-(--color-fg)">{player?.name}</p>
-                  <Show when={isActiveDropTarget}>
-                    <p class="text-[11px] text-(--color-muted)">{t('party.dropToSeat')}</p>
-                  </Show>
-                </div>
-              </button>
-            )
-          }}
-        </For>
-      </div>
+      <SeatMapBoard
+        entries={seatEntries()}
+        teamColors={state.settings.teamColors}
+        teamNames={teamNames()}
+        armedPlayerId={armedPlayerId()}
+        draggingPlayerId={draggingPlayerId()}
+        armedRecentName={armedRecentName()}
+        draggingRecentName={draggingRecentName()}
+        onSeatAssign={handleSeatAssign}
+        tableLabel={t('party.tableLabel')}
+        dropToSeatLabel={t('party.dropToSeat')}
+        seatActionLabel={(seat, name) => t('party.seatAction', { seat: t(`seats.${seat}`), name })}
+      />
 
       <Show when={editorDraft() && activePlayer()}>
-        <DialogShell closeLabel={t('party.closeEditor')} onClose={closeEditor} testId="party-editor-dialog">
-          <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
-              <div class="flex items-start justify-between gap-3">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
-                    {t('party.editorTitle')}
-                  </p>
-                  <p class="mt-2 text-sm text-(--color-muted)">
-                    {t('party.editorSubtitle', {
-                      seat: t(`seats.${activePlayer()!.seat}`),
-                    })}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)"
-                  aria-label={t('party.closeEditor')}
-                  onClick={closeEditor}
-                >
-                  ×
-                </button>
-              </div>
-
-              <div class="mt-5 grid gap-4">
-                <label class="grid gap-2 text-sm">
-                  <span class="text-(--color-muted)">{t('party.nameField')}</span>
-                  <input
-                    class="w-full rounded-2xl border border-white/14 bg-slate-950/85 px-4 py-3 text-(--color-fg) outline-none placeholder:text-(--color-muted) focus:border-(--color-accent)"
-                    value={editorDraft()!.name}
-                    onInput={(event) =>
-                      setEditorDraft((current) =>
-                        current ? { ...current, name: event.currentTarget.value } : current,
-                      )
-                    }
-                  />
-                </label>
-
-                <div class="grid gap-2">
-                  <span class="text-sm text-(--color-muted)">{t('party.quickActions')}</span>
-                  <div class="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      class="rounded-full border border-white/12 bg-slate-950/85 px-3 py-2 text-sm text-(--color-fg)"
-                      onClick={() =>
-                        setEditorDraft((current) =>
-                          current
-                            ? {
-                                ...current,
-                                name: getUniqueRandomName(state.players, state.settings.language, current),
-                              }
-                            : current,
-                        )
-                      }
-                    >
-                      {t('party.rerollName')}
-                    </button>
-                    <button
-                      type="button"
-                      class="rounded-full border border-white/12 bg-slate-950/85 px-3 py-2 text-sm text-(--color-fg)"
-                      onClick={() => {
-                        setArmedPlayerId(activePlayer()!.id)
-                        setArmedRecentName(null)
-                        closeEditor()
-                      }}
-                    >
-                      {t('party.moveSeat')}
-                    </button>
-                    <For each={recentNames()}>
-                      {(name) => (
-                        <button
-                          type="button"
-                          class="rounded-full border border-dashed border-white/14 bg-slate-950/80 px-3 py-2 text-sm text-(--color-fg) opacity-70"
-                          onClick={() => applyRecentName(name)}
-                        >
-                          {name}
-                        </button>
-                      )}
-                    </For>
-                  </div>
-                </div>
-
-                <Show when={errorMessage()}>
-                  <p class="rounded-2xl border border-rose-300/35 bg-rose-300/10 px-4 py-3 text-sm text-rose-50">
-                    {errorMessage()}
-                  </p>
-                </Show>
-              </div>
-          </div>
-
-          <DialogActions
-            primaryLabel={t('party.applyChanges')}
-            secondaryLabel={t('round.cancel')}
-            onPrimary={commitEditor}
-            onSecondary={closeEditor}
-          />
-        </DialogShell>
+        <PlayerEditorDialog
+          draft={editorDraft()!}
+          errorMessage={errorMessage()}
+          recentNames={recentNames()}
+          title={t('party.editorTitle')}
+          subtitle={t('party.editorSubtitle', { seat: t(`seats.${activePlayer()!.seat}`) })}
+          nameFieldLabel={t('party.nameField')}
+          quickActionsLabel={t('party.quickActions')}
+          rerollLabel={t('party.rerollName')}
+          moveSeatLabel={t('party.moveSeat')}
+          closeLabel={t('party.closeEditor')}
+          applyLabel={t('party.applyChanges')}
+          cancelLabel={t('round.cancel')}
+          onNameInput={(name) => setEditorDraft((current) => (current ? { ...current, name } : current))}
+          onRecentNameClick={(name) => setEditorDraft((current) => (current ? { ...current, name } : current))}
+          onReroll={() =>
+            setEditorDraft((current) =>
+              current ? { ...current, name: getUniqueRandomName(state.players, state.settings.language, current) } : current,
+            )
+          }
+          onMoveSeat={() => {
+            setArmedPlayerId(activePlayer()!.id)
+            setArmedRecentName(null)
+            closePlayerEditor()
+          }}
+          onClose={closePlayerEditor}
+          onApply={commitPlayerEditor}
+        />
       </Show>
 
-      <Show when={activeTeamEditor()}>
-        <DialogShell closeLabel={t('party.closeTeamEditor')} onClose={closeTeamEditor} testId="team-editor-dialog">
-          <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
-            <div class="flex items-start justify-between gap-3">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
-                  {t('party.teamEditorTitle')}
-                </p>
-                <p class="mt-2 text-sm text-(--color-muted)">
-                  {t('party.teamEditorSubtitle', {
-                    team: activeTeamEditor()!.teamId === 'north-south' ? '1' : '2',
-                  })}
-                </p>
-              </div>
-              <button
-                type="button"
-                class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)"
-                aria-label={t('party.closeTeamEditor')}
-                onClick={closeTeamEditor}
-              >
-                ×
-              </button>
-            </div>
-
-            <div class="mt-5 grid gap-5">
-              <label class="grid gap-2 text-sm">
-                <span class="text-(--color-muted)">{t('party.teamNameField')}</span>
-                <input
-                  class="w-full rounded-2xl border border-white/14 bg-slate-950/85 px-4 py-3 text-(--color-fg) outline-none placeholder:text-(--color-muted) focus:border-(--color-accent)"
-                  value={activeTeamEditor()!.name}
-                  onInput={(event) =>
-                    setTeamEditorDraft((current) =>
-                      current ? { ...current, name: event.currentTarget.value } : current,
-                    )
-                  }
-                  data-testid={`team-editor-name-${activeTeamEditor()!.teamId}`}
-                />
-              </label>
-
-              <div class="grid gap-3">
-                <span class="text-sm text-(--color-muted)">{t('party.teamColors')}</span>
-                <div class="grid grid-cols-4 gap-2">
-                  <For each={teamColorOptions}>
-                    {(color) => {
-                      const isDisabled = () =>
-                        color !== activeTeamEditor()!.color &&
-                        color === state.settings.teamColors[activeTeamEditor()!.teamId === 'north-south' ? 'east-west' : 'north-south']
-
-                      return (
-                        <button
-                          type="button"
-                          class={clsx(
-                            'grid gap-2 rounded-2xl border p-3 text-left transition-transform',
-                            teamColorClasses[color].chip,
-                            activeTeamEditor()!.color === color
-                              ? 'border-white shadow-[0_0_0_1px_rgba(255,255,255,0.12)]'
-                              : 'border-transparent',
-                            isDisabled()
-                              ? 'cursor-not-allowed opacity-30'
-                              : 'motion-safe:hover:-translate-y-0.5',
-                          )}
-                          aria-disabled={isDisabled()}
-                          aria-pressed={activeTeamEditor()!.color === color}
-                          disabled={isDisabled()}
-                          data-testid={`team-editor-color-${color}`}
-                          onClick={() =>
-                            setTeamEditorDraft((current) => (current ? { ...current, color } : current))
-                          }
-                        >
-                          <span class="h-3 w-8 rounded-full bg-black/20" />
-                          <span class="text-[11px] font-semibold uppercase tracking-[0.18em]">
-                            {color}
-                          </span>
-                        </button>
-                      )
-                    }}
-                  </For>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <DialogActions
-            primaryLabel={t('party.applyChanges')}
-            secondaryLabel={t('round.cancel')}
-            onPrimary={commitTeamEditor}
-            onSecondary={closeTeamEditor}
-          />
-        </DialogShell>
+      <Show when={teamEditorDraft()}>
+        <TeamEditorDialog
+          draft={teamEditorDraft()!}
+          oppositeTeamColor={state.settings.teamColors[activeTeamId(teamEditorDraft()!.teamId)]}
+          title={t('party.teamEditorTitle')}
+          subtitle={t('party.teamEditorSubtitle', {
+            team: teamEditorDraft()!.teamId === 'north-south' ? '1' : '2',
+          })}
+          closeLabel={t('party.closeTeamEditor')}
+          nameFieldLabel={t('party.teamNameField')}
+          teamColorsLabel={t('party.teamColors')}
+          applyLabel={t('party.applyChanges')}
+          cancelLabel={t('round.cancel')}
+          onNameInput={(name) => setTeamEditorDraft((current) => (current ? { ...current, name } : current))}
+          onColorSelect={(color) => setTeamEditorDraft((current) => (current ? { ...current, color } : current))}
+          onClose={() => setTeamEditorDraft(null)}
+          onApply={commitTeamEditor}
+        />
       </Show>
     </section>
   )
-}
-
-function getTeamId(seat: Seat): TeamId {
-  return seat === 'north' || seat === 'south' ? 'north-south' : 'east-west'
-}
-
-function TeamBadge(props: { teamId: TeamId }) {
-  const { state } = useGame()
-
-  return (
-    <span
-      class={clsx('h-3 w-3 rounded-full', teamColorClasses[state.settings.teamColors[props.teamId]].chip)}
-    />
-  )
-}
-
-function TeamSetupCard(props: {
-  teamId: TeamId
-  label: () => string
-  subtitle: () => string
-  selectedColor: () => TeamColor
-  oppositeColor: () => TeamColor
-  onOpenEditor: (teamId: TeamId) => void
-}) {
-  const { t } = useGame()
-
-  return (
-    <button
-      type="button"
-      class="rounded-3xl border border-white/10 bg-black/10 p-3 text-left transition-transform motion-safe:hover:-translate-y-0.5"
-      data-testid={`team-name-${props.teamId}`}
-      onClick={() => props.onOpenEditor(props.teamId)}
-    >
-      <div class="grid gap-3">
-        <div>
-          <p class="text-sm font-medium text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
-            {props.label()}
-          </p>
-          <p class="mt-1 text-[11px] text-(--color-muted)">{props.subtitle()}</p>
-        </div>
-        <div class="flex items-center justify-between gap-3">
-          <div class="flex flex-wrap gap-1.5">
-            <For each={teamColorOptions.slice(0, 4)}>
-              {(color) => (
-                <span
-                  class={clsx(
-                    'h-3 w-3 rounded-full border border-white/10',
-                    teamColorClasses[color].chip,
-                    props.selectedColor() !== color && props.oppositeColor() === color && 'opacity-25',
-                  )}
-                />
-              )}
-            </For>
-          </div>
-          <span class="text-[11px] uppercase tracking-[0.18em] text-(--color-muted)">{t('party.editTeam')}</span>
-        </div>
-      </div>
-    </button>
-  )
-}
-
-function DialogShell(props: ParentProps<{
-  closeLabel: string
-  onClose: () => void
-  testId: string
-}>) {
-  return (
-    <div class="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/82 p-0 backdrop-blur-md sm:items-center sm:p-6">
-      <button
-        type="button"
-        class="absolute inset-0"
-        aria-label={props.closeLabel}
-        onClick={() => props.onClose()}
-      />
-      <div
-        class="relative z-10 flex h-dvh max-h-dvh w-full flex-col overflow-hidden border-white/12 bg-[color-mix(in_srgb,var(--color-surface)_98%,#020617)] shadow-[0_28px_90px_rgba(0,0,0,0.42)] sm:h-auto sm:max-h-[min(100dvh-3rem,42rem)] sm:max-w-md sm:rounded-4xl sm:border"
-        data-testid={props.testId}
-      >
-        {props.children}
-      </div>
-    </div>
-  )
-}
-
-function DialogActions(props: {
-  primaryLabel: string
-  secondaryLabel: string
-  onPrimary: () => void
-  onSecondary: () => void
-}) {
-  return (
-    <div class="sticky bottom-0 flex gap-3 border-t border-white/10 bg-[color-mix(in_srgb,var(--color-surface)_98%,#020617)] px-5 pb-[calc(env(safe-area-inset-bottom)+1.25rem)] pt-4 sm:px-5 sm:pb-5">
-      <button
-        type="button"
-        class="flex-1 rounded-2xl bg-(--color-accent) px-4 py-3 text-sm font-semibold text-slate-950"
-        onClick={() => props.onPrimary()}
-      >
-        {props.primaryLabel}
-      </button>
-      <button
-        type="button"
-        class="rounded-2xl border border-white/10 px-4 py-3 text-sm text-(--color-fg)"
-        onClick={() => props.onSecondary()}
-      >
-        {props.secondaryLabel}
-      </button>
-    </div>
-  )
-}
-
-function getUniqueRandomName(players: Player[], language: Language, draft: EditorDraft) {
-  let nextName = getRandomPlayerName(language, draft.name)
-  let attempts = 0
-
-  while (
-    players.some(
-      (player) => player.id !== draft.playerId && player.name.trim().toLowerCase() === nextName.toLowerCase(),
-    ) &&
-    attempts < 12
-  ) {
-    nextName = getRandomPlayerName(language, nextName)
-    attempts += 1
-  }
-
-  return nextName
 }

--- a/src/features/party-setup/PartySetupDialogs.tsx
+++ b/src/features/party-setup/PartySetupDialogs.tsx
@@ -1,0 +1,238 @@
+import clsx from 'clsx'
+import { For, type ParentProps } from 'solid-js'
+import type { TeamColor } from '@/domain/types'
+import { teamColorClasses, teamColorOptions, type EditorDraft, type TeamEditorDraft } from './party-setup.shared'
+
+type PlayerEditorDialogProps = {
+  draft: EditorDraft
+  errorMessage: string
+  recentNames: string[]
+  title: string
+  subtitle: string
+  nameFieldLabel: string
+  quickActionsLabel: string
+  rerollLabel: string
+  moveSeatLabel: string
+  closeLabel: string
+  applyLabel: string
+  cancelLabel: string
+  onNameInput: (name: string) => void
+  onRecentNameClick: (name: string) => void
+  onReroll: () => void
+  onMoveSeat: () => void
+  onClose: () => void
+  onApply: () => void
+}
+
+type TeamEditorDialogProps = {
+  draft: TeamEditorDraft
+  oppositeTeamColor: TeamColor
+  title: string
+  subtitle: string
+  closeLabel: string
+  nameFieldLabel: string
+  teamColorsLabel: string
+  applyLabel: string
+  cancelLabel: string
+  onNameInput: (name: string) => void
+  onColorSelect: (color: TeamColor) => void
+  onClose: () => void
+  onApply: () => void
+}
+
+export function PlayerEditorDialog(props: PlayerEditorDialogProps) {
+  return (
+    <DialogShell closeLabel={props.closeLabel} onClose={props.onClose} testId="party-editor-dialog">
+      <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{props.title}</p>
+            <p class="mt-2 text-sm text-(--color-muted)">{props.subtitle}</p>
+          </div>
+          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} />
+        </div>
+
+        <div class="mt-5 grid gap-4">
+          <label class="grid gap-2 text-sm">
+            <span class="text-(--color-muted)">{props.nameFieldLabel}</span>
+            <input
+              class="w-full rounded-2xl border border-white/14 bg-slate-950/85 px-4 py-3 text-(--color-fg) outline-none placeholder:text-(--color-muted) focus:border-(--color-accent)"
+              value={props.draft.name}
+              onInput={(event) => props.onNameInput(event.currentTarget.value)}
+            />
+          </label>
+
+          <div class="grid gap-2">
+            <span class="text-sm text-(--color-muted)">{props.quickActionsLabel}</span>
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="rounded-full border border-white/12 bg-slate-950/85 px-3 py-2 text-sm text-(--color-fg)"
+                onClick={() => props.onReroll()}
+              >
+                {props.rerollLabel}
+              </button>
+              <button
+                type="button"
+                class="rounded-full border border-white/12 bg-slate-950/85 px-3 py-2 text-sm text-(--color-fg)"
+                onClick={() => props.onMoveSeat()}
+              >
+                {props.moveSeatLabel}
+              </button>
+              <For each={props.recentNames}>
+                {(name) => (
+                  <button
+                    type="button"
+                    class="rounded-full border border-dashed border-white/14 bg-slate-950/80 px-3 py-2 text-sm text-(--color-fg) opacity-70"
+                    onClick={() => props.onRecentNameClick(name)}
+                  >
+                    {name}
+                  </button>
+                )}
+              </For>
+            </div>
+          </div>
+
+          {props.errorMessage ? (
+            <p class="rounded-2xl border border-rose-300/35 bg-rose-300/10 px-4 py-3 text-sm text-rose-50">
+              {props.errorMessage}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <DialogActions
+        primaryLabel={props.applyLabel}
+        secondaryLabel={props.cancelLabel}
+        onPrimary={props.onApply}
+        onSecondary={props.onClose}
+      />
+    </DialogShell>
+  )
+}
+
+export function TeamEditorDialog(props: TeamEditorDialogProps) {
+  return (
+    <DialogShell closeLabel={props.closeLabel} onClose={props.onClose} testId="team-editor-dialog">
+      <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{props.title}</p>
+            <p class="mt-2 text-sm text-(--color-muted)">{props.subtitle}</p>
+          </div>
+          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} />
+        </div>
+
+        <div class="mt-5 grid gap-5">
+          <label class="grid gap-2 text-sm">
+            <span class="text-(--color-muted)">{props.nameFieldLabel}</span>
+            <input
+              class="w-full rounded-2xl border border-white/14 bg-slate-950/85 px-4 py-3 text-(--color-fg) outline-none placeholder:text-(--color-muted) focus:border-(--color-accent)"
+              value={props.draft.name}
+              onInput={(event) => props.onNameInput(event.currentTarget.value)}
+              data-testid={`team-editor-name-${props.draft.teamId}`}
+            />
+          </label>
+
+          <div class="grid gap-3">
+            <span class="text-sm text-(--color-muted)">{props.teamColorsLabel}</span>
+            <div class="grid grid-cols-4 gap-2">
+              <For each={teamColorOptions}>
+                {(color) => {
+                  const isDisabled = () => color !== props.draft.color && color === props.oppositeTeamColor
+
+                  return (
+                    <button
+                      type="button"
+                      class={clsx(
+                        'grid gap-2 rounded-2xl border p-3 text-left transition-transform',
+                        teamColorClasses[color].chip,
+                        props.draft.color === color
+                          ? 'border-white shadow-[0_0_0_1px_rgba(255,255,255,0.12)]'
+                          : 'border-transparent',
+                        isDisabled() ? 'cursor-not-allowed opacity-30' : 'motion-safe:hover:-translate-y-0.5',
+                      )}
+                      aria-disabled={isDisabled()}
+                      aria-pressed={props.draft.color === color}
+                      disabled={isDisabled()}
+                      data-testid={`team-editor-color-${color}`}
+                      onClick={() => props.onColorSelect(color)}
+                    >
+                      <span class="h-3 w-8 rounded-full bg-black/20" />
+                      <span class="text-[11px] font-semibold uppercase tracking-[0.18em]">{color}</span>
+                    </button>
+                  )
+                }}
+              </For>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogActions
+        primaryLabel={props.applyLabel}
+        secondaryLabel={props.cancelLabel}
+        onPrimary={props.onApply}
+        onSecondary={props.onClose}
+      />
+    </DialogShell>
+  )
+}
+
+function DialogCloseButton(props: { closeLabel: string; onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)"
+      aria-label={props.closeLabel}
+      onClick={() => props.onClose()}
+    >
+      ×
+    </button>
+  )
+}
+
+function DialogShell(props: ParentProps<{ closeLabel: string; onClose: () => void; testId: string }>) {
+  return (
+    <div class="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/82 p-0 backdrop-blur-md sm:items-center sm:p-6">
+      <button
+        type="button"
+        class="absolute inset-0"
+        aria-label={props.closeLabel}
+        onClick={() => props.onClose()}
+      />
+      <div
+        class="relative z-10 flex h-dvh max-h-dvh w-full flex-col overflow-hidden border-white/12 bg-[color-mix(in_srgb,var(--color-surface)_98%,#020617)] shadow-[0_28px_90px_rgba(0,0,0,0.42)] sm:h-auto sm:max-h-[min(100dvh-3rem,42rem)] sm:max-w-md sm:rounded-4xl sm:border"
+        data-testid={props.testId}
+      >
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+function DialogActions(props: {
+  primaryLabel: string
+  secondaryLabel: string
+  onPrimary: () => void
+  onSecondary: () => void
+}) {
+  return (
+    <div class="sticky bottom-0 flex gap-3 border-t border-white/10 bg-[color-mix(in_srgb,var(--color-surface)_98%,#020617)] px-5 pb-[calc(env(safe-area-inset-bottom)+1.25rem)] pt-4 sm:px-5 sm:pb-5">
+      <button
+        type="button"
+        class="flex-1 rounded-2xl bg-(--color-accent) px-4 py-3 text-sm font-semibold text-slate-950"
+        onClick={() => props.onPrimary()}
+      >
+        {props.primaryLabel}
+      </button>
+      <button
+        type="button"
+        class="rounded-2xl border border-white/10 px-4 py-3 text-sm text-(--color-fg)"
+        onClick={() => props.onSecondary()}
+      >
+        {props.secondaryLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/features/party-setup/SeatMapBoard.tsx
+++ b/src/features/party-setup/SeatMapBoard.tsx
@@ -1,0 +1,103 @@
+import clsx from 'clsx'
+import { For, Show } from 'solid-js'
+import type { Player, PlayerId, Seat, TeamColor, TeamId } from '@/domain/types'
+import { TeamBadge } from './TeamSetupCard'
+import { getTeamId, seatLayouts, seatOverlayLabels, teamColorClasses } from './party-setup.shared'
+
+type SeatEntry = {
+  seat: Seat
+  className: string
+  player: Player | null
+}
+
+type SeatMapBoardProps = {
+  entries: SeatEntry[]
+  teamColors: Record<TeamId, TeamColor>
+  teamNames: Record<TeamId, string>
+  armedPlayerId: PlayerId | null
+  draggingPlayerId: PlayerId | null
+  armedRecentName: string | null
+  draggingRecentName: string | null
+  onSeatAssign: (seat: Seat) => void
+  tableLabel: string
+  dropToSeatLabel: string
+  seatActionLabel: (seat: Seat, name: string) => string
+}
+
+export function SeatMapBoard(props: SeatMapBoardProps) {
+  return (
+    <div
+      class="grid min-h-96 grid-cols-[minmax(0,1fr)_4.5rem_minmax(0,1fr)] grid-rows-[auto_minmax(6rem,1fr)_auto] gap-3"
+      aria-label={props.tableLabel}
+    >
+      <div class="col-start-2 row-start-2 flex items-center justify-center">
+        <div class="flex h-full w-full items-center justify-center rounded-4xl border border-white/10 bg-[radial-gradient(circle_at_top,rgba(255,191,105,0.18),rgba(15,23,42,0.94))] p-4 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
+          <div class="grid place-items-center gap-2">
+            <div class="h-12 w-12 rounded-full border border-white/12 bg-black/18 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]" />
+            <p class="text-[10px] uppercase tracking-[0.3em] text-(--color-muted)">Tichu</p>
+          </div>
+        </div>
+      </div>
+
+      <For each={props.entries}>
+        {(entry) => {
+          const player = entry.player
+          const teamId = player ? getTeamId(player.seat) : getTeamId(entry.seat)
+          const colors = teamColorClasses[props.teamColors[teamId]]
+          const isActiveDropTarget = Boolean(
+            props.armedPlayerId || props.draggingPlayerId || props.armedRecentName || props.draggingRecentName,
+          )
+
+          return (
+            <button
+              type="button"
+              class={clsx(
+                entry.className,
+                'relative flex min-h-28 flex-col justify-between overflow-hidden rounded-3xl border border-white/10 bg-(--color-surface) p-3 text-left',
+                'ring-1 transition-transform duration-200 ease-out motion-safe:hover:-translate-y-0.5',
+                colors.ring,
+                colors.glow,
+                isActiveDropTarget && 'border-dashed border-(--color-accent)',
+              )}
+              aria-label={props.seatActionLabel(entry.seat, player?.name ?? '')}
+              onClick={() => props.onSeatAssign(entry.seat)}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={() => props.onSeatAssign(entry.seat)}
+              data-testid={`seat-${entry.seat}`}
+            >
+              <div class={clsx('pointer-events-none absolute inset-0 bg-linear-to-br opacity-70', colors.surface)} />
+              <span
+                class="pointer-events-none absolute inset-0 flex items-center justify-center text-[clamp(3.5rem,20vw,5.25rem)] font-black tracking-[-0.08em] text-white/6"
+                aria-hidden="true"
+                data-testid={`seat-overlay-${entry.seat}`}
+              >
+                {seatOverlayLabels[entry.seat]}
+              </span>
+              <div class="relative flex items-start justify-end gap-2">
+                <span class="inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/18 px-2 py-1 text-[10px] text-(--color-muted)">
+                  <TeamBadge color={props.teamColors[teamId]} />
+                  {props.teamNames[teamId]}
+                </span>
+              </div>
+
+              <div class="relative grid gap-1">
+                <p class="text-lg font-semibold tracking-[-0.02em] text-(--color-fg)">{player?.name}</p>
+                <Show when={isActiveDropTarget}>
+                  <p class="text-[11px] text-(--color-muted)">{props.dropToSeatLabel}</p>
+                </Show>
+              </div>
+            </button>
+          )
+        }}
+      </For>
+    </div>
+  )
+}
+
+export function createSeatEntries(players: Player[]) {
+  return seatLayouts.map(({ seat, className }) => ({
+    seat,
+    className,
+    player: players.find((item) => item.seat === seat) ?? null,
+  }))
+}

--- a/src/features/party-setup/TeamSetupCard.tsx
+++ b/src/features/party-setup/TeamSetupCard.tsx
@@ -1,0 +1,54 @@
+import clsx from 'clsx'
+import { For } from 'solid-js'
+import type { TeamColor, TeamId } from '@/domain/types'
+import { teamColorClasses, teamColorOptions } from './party-setup.shared'
+
+type TeamSetupCardProps = {
+  teamId: TeamId
+  label: string
+  subtitle: string
+  selectedColor: TeamColor
+  oppositeColor: TeamColor
+  editLabel: string
+  onOpenEditor: (teamId: TeamId) => void
+}
+
+export function TeamSetupCard(props: TeamSetupCardProps) {
+  return (
+    <button
+      type="button"
+      class="rounded-3xl border border-white/10 bg-black/10 p-3 text-left transition-transform motion-safe:hover:-translate-y-0.5"
+      data-testid={`team-name-${props.teamId}`}
+      onClick={() => props.onOpenEditor(props.teamId)}
+    >
+      <div class="grid gap-3">
+        <div>
+          <p class="text-sm font-medium text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
+            {props.label}
+          </p>
+          <p class="mt-1 text-[11px] text-(--color-muted)">{props.subtitle}</p>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex flex-wrap gap-1.5">
+            <For each={teamColorOptions.slice(0, 4)}>
+              {(color) => (
+                <span
+                  class={clsx(
+                    'h-3 w-3 rounded-full border border-white/10',
+                    teamColorClasses[color].chip,
+                    props.selectedColor !== color && props.oppositeColor === color && 'opacity-25',
+                  )}
+                />
+              )}
+            </For>
+          </div>
+          <span class="text-[11px] uppercase tracking-[0.18em] text-(--color-muted)">{props.editLabel}</span>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+export function TeamBadge(props: { color: TeamColor }) {
+  return <span class={clsx('h-3 w-3 rounded-full', teamColorClasses[props.color].chip)} />
+}

--- a/src/features/party-setup/party-setup.shared.ts
+++ b/src/features/party-setup/party-setup.shared.ts
@@ -1,0 +1,95 @@
+import { getRandomPlayerName } from '@/domain/defaults'
+import type { Language, Player, PlayerId, Seat, TeamColor, TeamId } from '@/domain/types'
+
+export const teamColorClasses: Record<TeamColor, { chip: string; ring: string; surface: string; glow: string }> = {
+  amber: {
+    chip: 'bg-amber-300 text-amber-950',
+    ring: 'ring-amber-300/55',
+    surface: 'from-amber-300/18 to-amber-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(252,211,77,0.24),0_18px_50px_rgba(252,211,77,0.14)]',
+  },
+  emerald: {
+    chip: 'bg-emerald-300 text-emerald-950',
+    ring: 'ring-emerald-300/55',
+    surface: 'from-emerald-300/18 to-emerald-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(110,231,183,0.24),0_18px_50px_rgba(110,231,183,0.14)]',
+  },
+  sky: {
+    chip: 'bg-sky-300 text-sky-950',
+    ring: 'ring-sky-300/55',
+    surface: 'from-sky-300/18 to-sky-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(125,211,252,0.24),0_18px_50px_rgba(125,211,252,0.14)]',
+  },
+  rose: {
+    chip: 'bg-rose-300 text-rose-950',
+    ring: 'ring-rose-300/55',
+    surface: 'from-rose-300/18 to-rose-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(253,164,175,0.24),0_18px_50px_rgba(253,164,175,0.14)]',
+  },
+  violet: {
+    chip: 'bg-violet-300 text-violet-950',
+    ring: 'ring-violet-300/55',
+    surface: 'from-violet-300/18 to-violet-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(196,181,253,0.24),0_18px_50px_rgba(196,181,253,0.14)]',
+  },
+  teal: {
+    chip: 'bg-teal-300 text-teal-950',
+    ring: 'ring-teal-300/55',
+    surface: 'from-teal-300/18 to-teal-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(94,234,212,0.24),0_18px_50px_rgba(94,234,212,0.14)]',
+  },
+  orange: {
+    chip: 'bg-orange-300 text-orange-950',
+    ring: 'ring-orange-300/55',
+    surface: 'from-orange-300/18 to-orange-100/4',
+    glow: 'shadow-[0_0_0_1px_rgba(253,186,116,0.24),0_18px_50px_rgba(253,186,116,0.14)]',
+  },
+}
+
+export const teamColorOptions: TeamColor[] = ['amber', 'sky', 'emerald', 'rose', 'violet', 'teal', 'orange']
+
+export const seatLayouts: { seat: Seat; className: string }[] = [
+  { seat: 'north', className: 'col-start-2 row-start-1' },
+  { seat: 'west', className: 'col-start-1 row-start-2' },
+  { seat: 'east', className: 'col-start-3 row-start-2' },
+  { seat: 'south', className: 'col-start-2 row-start-3' },
+]
+
+export const seatOverlayLabels: Record<Seat, string> = {
+  north: 'N',
+  west: 'W',
+  east: 'E',
+  south: 'S',
+}
+
+export type EditorDraft = {
+  playerId: PlayerId
+  name: string
+}
+
+export type TeamEditorDraft = {
+  teamId: TeamId
+  name: string
+  color: TeamColor
+}
+
+export function getTeamId(seat: Seat): TeamId {
+  return seat === 'north' || seat === 'south' ? 'north-south' : 'east-west'
+}
+
+export function getUniqueRandomName(players: Player[], language: Language, draft: EditorDraft) {
+  let nextName = getRandomPlayerName(language, draft.name)
+  let attempts = 0
+
+  while (
+    players.some(
+      (player) => player.id !== draft.playerId && player.name.trim().toLowerCase() === nextName.toLowerCase(),
+    ) &&
+    attempts < 12
+  ) {
+    nextName = getRandomPlayerName(language, nextName)
+    attempts += 1
+  }
+
+  return nextName
+}


### PR DESCRIPTION
## Summary
- split PartySetup into bench, seat-map, dialog, team-card, and shared helper modules
- reduce PartySetup.tsx to a container under the 300-line target
- keep the existing party-setup behavior and tests intact while establishing the file-length refactor pattern for the rest of the backlog

Closes #63