### PR TITLE
refactor: split the round entry feature

### DIFF
--- a/src/features/rounds/RoundEntry.tsx
+++ b/src/features/rounds/RoundEntry.tsx
@@ -1,22 +1,21 @@
 import clsx from 'clsx'
 import { For, Show, createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
-import { createDefaultTichuCalls } from '@/domain/defaults'
 import { validateRoundInput } from '@/domain/scoring'
-import type { Player, RoundInput, TeamId, TichuCall } from '@/domain/types'
 import { useGame } from '@/state/game-context'
+import { RoundMetaFields } from './RoundMetaFields'
+import { RoundPlayerList } from './RoundPlayerList'
+import {
+  buildRoundInput,
+  createDraft,
+  createDraftFromRound,
+  formatElapsedMs,
+  type RoundDraft,
+} from './round-entry.shared'
 
 type RoundEntryProps = {
   editingRoundId: string | null
   onEditingRoundIdChange: (roundId: string | null) => void
-}
-
-type RoundDraft = {
-  firstOutPlayerId: Player['id']
-  doubleVictoryTeamId: TeamId | ''
-  cardPointsNorthSouth: string
-  cardPointsEastWest: string
-  tichuCalls: Record<Player['id'], TichuCall>
 }
 
 export function RoundEntry(props: RoundEntryProps) {
@@ -25,9 +24,7 @@ export function RoundEntry(props: RoundEntryProps) {
   const [errors, setErrors] = createSignal<string[]>([])
   const [now, setNow] = createSignal(Date.now())
   const [statusMessage, setStatusMessage] = createSignal('')
-  const editingRound = createMemo(() =>
-    props.editingRoundId ? findRound(props.editingRoundId) : undefined,
-  )
+  const editingRound = createMemo(() => (props.editingRoundId ? findRound(props.editingRoundId) : undefined))
   const editingRoundIndex = createMemo(() =>
     props.editingRoundId ? state.rounds.findIndex((round) => round.id === props.editingRoundId) : -1,
   )
@@ -36,12 +33,12 @@ export function RoundEntry(props: RoundEntryProps) {
     const currentRound = editingRound()
 
     if (!currentRound) {
-      setDraft(replaceDraft(createDraft(state.players)))
+      setDraft(reconcile(createDraft(state.players)))
       setErrors([])
       return
     }
 
-    setDraft(replaceDraft(createDraftFromRound(currentRound.input)))
+    setDraft(reconcile(createDraftFromRound(currentRound.input)))
     setErrors([])
   })
 
@@ -54,29 +51,56 @@ export function RoundEntry(props: RoundEntryProps) {
   const timer = window.setInterval(() => setNow(Date.now()), 1000)
   onCleanup(() => window.clearInterval(timer))
 
-  const activeRoundElapsed = createMemo(() => {
-    if (!state.activeRoundStartedAt) {
-      return null
-    }
-
-    return formatElapsedMs(now() - new Date(state.activeRoundStartedAt).getTime())
-  })
-
+  const activeRoundElapsed = createMemo(() =>
+    state.activeRoundStartedAt ? formatElapsedMs(now() - new Date(state.activeRoundStartedAt).getTime()) : null,
+  )
   const lastRoundElapsed = createMemo(() => {
     const lastRound = state.rounds.at(-1)
     return lastRound ? formatElapsedMs(lastRound.timing.elapsedMs) : null
   })
-
   const submitLabel = () => (props.editingRoundId ? t('round.update') : t('round.save'))
   const shouldShowForm = () => Boolean(props.editingRoundId || state.activeRoundStartedAt)
+
+  const resetDraft = () => setDraft(reconcile(createDraft(state.players)))
+
+  const submitRound = () => {
+    const input = buildRoundInput(draft)
+    const validation = validateRoundInput(state.players, input)
+
+    if (!validation.ok) {
+      setErrors(validation.errors.map((error) => error.message))
+      setStatusMessage('')
+      return
+    }
+
+    if (props.editingRoundId) {
+      updateRound(props.editingRoundId, input)
+      props.onEditingRoundIdChange(null)
+      setStatusMessage(t('actions.updateSuccess'))
+    } else {
+      addRound(input)
+      setStatusMessage(t('actions.saveSuccess'))
+    }
+
+    resetDraft()
+    setErrors([])
+  }
+
+  const cancelRound = () => {
+    if (props.editingRoundId) {
+      props.onEditingRoundIdChange(null)
+      resetDraft()
+    }
+
+    setErrors([])
+    cancelActiveRound()
+  }
 
   return (
     <section class="rounded-4xl border border-white/10 bg-white/8 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.18)] backdrop-blur-sm sm:p-6">
       <div class="flex items-start justify-between gap-4">
         <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">
-            {t('sections.round')}
-          </p>
+          <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{t('sections.round')}</p>
           <p class="mt-2 text-sm leading-6 text-(--color-muted)">{t('round.cardPointsHint')}</p>
         </div>
         <Show when={props.editingRoundId && editingRoundIndex() >= 0}>
@@ -92,9 +116,7 @@ export function RoundEntry(props: RoundEntryProps) {
             {state.rounds.length > 0 ? t('round.nextRoundPrompt') : t('round.firstRoundPrompt')}
           </p>
           <Show when={lastRoundElapsed()}>
-            <p class="text-sm text-(--color-muted)">
-              {t('round.previousElapsed', { elapsed: lastRoundElapsed()! })}
-            </p>
+            <p class="text-sm text-(--color-muted)">{t('round.previousElapsed', { elapsed: lastRoundElapsed()! })}</p>
           </Show>
           <button
             type="button"
@@ -126,244 +148,64 @@ export function RoundEntry(props: RoundEntryProps) {
 
       <Show when={shouldShowForm()}>
         <form
-        class="mt-5 space-y-5"
-        onSubmit={(event) => {
-          event.preventDefault()
+          class="mt-5 space-y-5"
+          onSubmit={(event) => {
+            event.preventDefault()
+            submitRound()
+          }}
+        >
+          <RoundPlayerList
+            players={state.players}
+            draft={draft}
+            t={t}
+            onTichuCallChange={(playerId, value) => setDraft('tichuCalls', playerId, value)}
+            onFirstOutChange={(playerId) => setDraft('firstOutPlayerId', playerId)}
+          />
 
-          const input = buildRoundInput(draft)
-          const validation = validateRoundInput(state.players, input)
+          <RoundMetaFields
+            draft={draft}
+            t={t}
+            onDoubleVictoryChange={(teamId) => setDraft('doubleVictoryTeamId', teamId)}
+            onCardPointsNorthSouthChange={(value) => setDraft('cardPointsNorthSouth', value)}
+            onCardPointsEastWestChange={(value) => setDraft('cardPointsEastWest', value)}
+          />
 
-          if (!validation.ok) {
-            setErrors(validation.errors.map((error) => error.message))
-            setStatusMessage('')
-            return
-          }
+          <Show when={errors().length > 0}>
+            <div class="rounded-[1.25rem] border border-rose-400/30 bg-rose-400/10 px-4 py-3 text-sm text-rose-100">
+              <ul class="space-y-1">
+                <For each={errors()}>{(error) => <li>{error}</li>}</For>
+              </ul>
+            </div>
+          </Show>
 
-          if (props.editingRoundId) {
-            updateRound(props.editingRoundId, input)
-            props.onEditingRoundIdChange(null)
-            setStatusMessage(t('actions.updateSuccess'))
-          } else {
-            addRound(input)
-            setStatusMessage(t('actions.saveSuccess'))
-          }
+          <Show when={statusMessage()}>
+            <div class="rounded-[1.25rem] border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-50">
+              {statusMessage()}
+            </div>
+          </Show>
 
-          setDraft(replaceDraft(createDraft(state.players)))
-          setErrors([])
-        }}
-      >
-        <div class="grid gap-3">
-          <For each={state.players}>
-            {(player) => (
-              <article class="rounded-3xl border border-white/10 bg-(--color-surface) p-4">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <p class="text-sm font-semibold text-(--color-fg)">{player.name}</p>
-                    <p class="text-xs uppercase tracking-[0.2em] text-(--color-muted)">
-                      {t(`seats.${player.seat}`)}
-                    </p>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <label class="text-xs text-(--color-muted)" for={`call-${player.id}`}>
-                      {t('round.tichu')}
-                    </label>
-                    <select
-                      id={`call-${player.id}`}
-                      class={clsx(
-                        'rounded-full border border-white/10 bg-black/15 px-3 py-2',
-                        'text-sm text-(--color-fg) outline-none focus:border-(--color-accent)',
-                      )}
-                      value={draft.tichuCalls[player.id]}
-                      data-testid={`tichu-call-${player.id}`}
-                      onInput={(event) =>
-                        setDraft('tichuCalls', player.id, event.currentTarget.value as TichuCall)
-                      }
-                    >
-                      <option value="none">{t('round.noCall')}</option>
-                      <option value="small">{t('round.small')}</option>
-                      <option value="grand">{t('round.grand')}</option>
-                    </select>
-                  </div>
-                </div>
-                <label class="mt-4 flex items-center gap-3 rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-(--color-fg)">
-                  <input
-                    type="radio"
-                    name="first-out-player"
-                    checked={draft.firstOutPlayerId === player.id}
-                    data-testid={`first-out-${player.id}`}
-                    onChange={() => setDraft('firstOutPlayerId', player.id)}
-                  />
-                  <span>{t('round.firstOut')}</span>
-                </label>
-              </article>
-            )}
-          </For>
-        </div>
-
-        <div class="grid gap-4 rounded-3xl border border-white/10 bg-(--color-surface) p-4 sm:grid-cols-3">
-          <label class="grid gap-2 text-sm">
-            <span class="text-(--color-muted)">{t('round.doubleVictory')}</span>
-            <select
+          <div class="sticky bottom-3 z-10 flex gap-3 rounded-3xl border border-white/10 bg-[color-mix(in_srgb,var(--color-bg)_78%,transparent)] p-3 backdrop-blur">
+            <button
+              type="submit"
               class={clsx(
-                'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
-                'text-(--color-fg) outline-none focus:border-(--color-accent)',
+                'flex-1 rounded-2xl bg-(--color-accent) px-4 py-3',
+                'text-sm font-semibold text-slate-950',
+                'transition-transform duration-150 motion-safe:hover:-translate-y-0.5',
               )}
-              value={draft.doubleVictoryTeamId}
-              data-testid="double-victory-team"
-              onInput={(event) =>
-                setDraft('doubleVictoryTeamId', event.currentTarget.value as TeamId | '')
-              }
+              data-testid="save-round"
             >
-              <option value="">{t('round.noDoubleVictory')}</option>
-              <option value="north-south">{t('teams.northSouth')}</option>
-              <option value="east-west">{t('teams.eastWest')}</option>
-            </select>
-          </label>
-
-          <label class="grid gap-2 text-sm">
-            <span class="text-(--color-muted)">{t('teams.northSouth')}</span>
-            <input
-              inputMode="numeric"
-              type="number"
-              min="0"
-              max="100"
-              disabled={Boolean(draft.doubleVictoryTeamId)}
-              class={clsx(
-                'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
-                'text-(--color-fg) outline-none transition-opacity',
-                'focus:border-(--color-accent)',
-                'disabled:cursor-not-allowed disabled:opacity-40',
-              )}
-              value={draft.cardPointsNorthSouth}
-              data-testid="card-points-north-south"
-              onInput={(event) => setDraft('cardPointsNorthSouth', event.currentTarget.value)}
-            />
-          </label>
-
-          <label class="grid gap-2 text-sm">
-            <span class="text-(--color-muted)">{t('teams.eastWest')}</span>
-            <input
-              inputMode="numeric"
-              type="number"
-              min="0"
-              max="100"
-              disabled={Boolean(draft.doubleVictoryTeamId)}
-              class={clsx(
-                'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
-                'text-(--color-fg) outline-none transition-opacity',
-                'focus:border-(--color-accent)',
-                'disabled:cursor-not-allowed disabled:opacity-40',
-              )}
-              value={draft.cardPointsEastWest}
-              data-testid="card-points-east-west"
-              onInput={(event) => setDraft('cardPointsEastWest', event.currentTarget.value)}
-            />
-          </label>
-        </div>
-
-        <Show when={errors().length > 0}>
-          <div class="rounded-[1.25rem] border border-rose-400/30 bg-rose-400/10 px-4 py-3 text-sm text-rose-100">
-            <ul class="space-y-1">
-              <For each={errors()}>{(error) => <li>{error}</li>}</For>
-            </ul>
-          </div>
-        </Show>
-
-        <Show when={statusMessage()}>
-          <div class="rounded-[1.25rem] border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-50">
-            {statusMessage()}
-          </div>
-        </Show>
-
-        <div class="sticky bottom-3 z-10 flex gap-3 rounded-3xl border border-white/10 bg-[color-mix(in_srgb,var(--color-bg)_78%,transparent)] p-3 backdrop-blur">
-          <button
-            type="submit"
-            class={clsx(
-              'flex-1 rounded-2xl bg-(--color-accent) px-4 py-3',
-              'text-sm font-semibold text-slate-950',
-              'transition-transform duration-150 motion-safe:hover:-translate-y-0.5',
-            )}
-            data-testid="save-round"
-          >
-            {submitLabel()}
-          </button>
-          <Show when={props.editingRoundId}>
+              {submitLabel()}
+            </button>
             <button
               type="button"
               class="rounded-2xl border border-white/12 px-4 py-3 text-sm text-(--color-fg)"
-              onClick={() => {
-                props.onEditingRoundIdChange(null)
-                setDraft(replaceDraft(createDraft(state.players)))
-                setErrors([])
-                cancelActiveRound()
-              }}
+              onClick={cancelRound}
             >
               {t('round.cancel')}
             </button>
-          </Show>
-          <Show when={!props.editingRoundId}>
-            <button
-              type="button"
-              class="rounded-2xl border border-white/12 px-4 py-3 text-sm text-(--color-fg)"
-              onClick={() => {
-                cancelActiveRound()
-                setErrors([])
-              }}
-            >
-              {t('round.cancel')}
-            </button>
-          </Show>
-        </div>
-      </form>
+          </div>
+        </form>
       </Show>
     </section>
   )
-}
-
-function createDraft(players: Player[]): RoundDraft {
-  return {
-    firstOutPlayerId: players[0]?.id ?? 'player-1',
-    doubleVictoryTeamId: '',
-    cardPointsNorthSouth: '50',
-    cardPointsEastWest: '50',
-    tichuCalls: createDefaultTichuCalls(),
-  }
-}
-
-function createDraftFromRound(input: RoundInput): RoundDraft {
-  return {
-    firstOutPlayerId: input.firstOutPlayerId,
-    doubleVictoryTeamId: input.doubleVictoryTeamId ?? '',
-    cardPointsNorthSouth: input.cardPoints ? String(input.cardPoints['north-south']) : '50',
-    cardPointsEastWest: input.cardPoints ? String(input.cardPoints['east-west']) : '50',
-    tichuCalls: { ...input.tichuCalls },
-  }
-}
-
-function replaceDraft(draft: RoundDraft) {
-  return reconcile(draft)
-}
-
-function buildRoundInput(draft: RoundDraft): RoundInput {
-  const doubleVictoryTeamId = draft.doubleVictoryTeamId || null
-
-  return {
-    firstOutPlayerId: draft.firstOutPlayerId,
-    doubleVictoryTeamId,
-    tichuCalls: { ...draft.tichuCalls },
-    cardPoints: doubleVictoryTeamId
-      ? null
-      : {
-          'north-south': Number(draft.cardPointsNorthSouth || 0),
-          'east-west': Number(draft.cardPointsEastWest || 0),
-        },
-  }
-}
-
-function formatElapsedMs(value: number) {
-  const totalSeconds = Math.max(0, Math.floor(value / 1000))
-  const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0')
-  const seconds = String(totalSeconds % 60).padStart(2, '0')
-
-  return `${minutes}:${seconds}`
 }

--- a/src/features/rounds/RoundMetaFields.tsx
+++ b/src/features/rounds/RoundMetaFields.tsx
@@ -1,0 +1,75 @@
+import clsx from 'clsx'
+import type { TeamId } from '@/domain/types'
+import type { TranslationKey } from '@/shared/i18n'
+import type { RoundDraft } from './round-entry.shared'
+
+type RoundMetaFieldsProps = {
+  draft: RoundDraft
+  t: (key: TranslationKey) => string
+  onDoubleVictoryChange: (teamId: TeamId | '') => void
+  onCardPointsNorthSouthChange: (value: string) => void
+  onCardPointsEastWestChange: (value: string) => void
+}
+
+export function RoundMetaFields(props: RoundMetaFieldsProps) {
+  return (
+    <div class="grid gap-4 rounded-3xl border border-white/10 bg-(--color-surface) p-4 sm:grid-cols-3">
+      <label class="grid gap-2 text-sm">
+        <span class="text-(--color-muted)">{props.t('round.doubleVictory')}</span>
+        <select
+          class={clsx(
+            'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
+            'text-(--color-fg) outline-none focus:border-(--color-accent)',
+          )}
+          value={props.draft.doubleVictoryTeamId}
+          data-testid="double-victory-team"
+          onInput={(event) => props.onDoubleVictoryChange(event.currentTarget.value as TeamId | '')}
+        >
+          <option value="">{props.t('round.noDoubleVictory')}</option>
+          <option value="north-south">{props.t('teams.northSouth')}</option>
+          <option value="east-west">{props.t('teams.eastWest')}</option>
+        </select>
+      </label>
+
+      <label class="grid gap-2 text-sm">
+        <span class="text-(--color-muted)">{props.t('teams.northSouth')}</span>
+        <input
+          inputMode="numeric"
+          type="number"
+          min="0"
+          max="100"
+          disabled={Boolean(props.draft.doubleVictoryTeamId)}
+          class={clsx(
+            'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
+            'text-(--color-fg) outline-none transition-opacity',
+            'focus:border-(--color-accent)',
+            'disabled:cursor-not-allowed disabled:opacity-40',
+          )}
+          value={props.draft.cardPointsNorthSouth}
+          data-testid="card-points-north-south"
+          onInput={(event) => props.onCardPointsNorthSouthChange(event.currentTarget.value)}
+        />
+      </label>
+
+      <label class="grid gap-2 text-sm">
+        <span class="text-(--color-muted)">{props.t('teams.eastWest')}</span>
+        <input
+          inputMode="numeric"
+          type="number"
+          min="0"
+          max="100"
+          disabled={Boolean(props.draft.doubleVictoryTeamId)}
+          class={clsx(
+            'rounded-2xl border border-white/10 bg-black/15 px-4 py-3',
+            'text-(--color-fg) outline-none transition-opacity',
+            'focus:border-(--color-accent)',
+            'disabled:cursor-not-allowed disabled:opacity-40',
+          )}
+          value={props.draft.cardPointsEastWest}
+          data-testid="card-points-east-west"
+          onInput={(event) => props.onCardPointsEastWestChange(event.currentTarget.value)}
+        />
+      </label>
+    </div>
+  )
+}

--- a/src/features/rounds/RoundPlayerList.tsx
+++ b/src/features/rounds/RoundPlayerList.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx'
+import { For } from 'solid-js'
+import type { Player, TichuCall } from '@/domain/types'
+import type { TranslationKey } from '@/shared/i18n'
+import type { RoundDraft } from './round-entry.shared'
+
+type RoundPlayerListProps = {
+  players: Player[]
+  draft: RoundDraft
+  t: (key: TranslationKey) => string
+  onTichuCallChange: (playerId: Player['id'], value: TichuCall) => void
+  onFirstOutChange: (playerId: Player['id']) => void
+}
+
+export function RoundPlayerList(props: RoundPlayerListProps) {
+  return (
+    <div class="grid gap-3">
+      <For each={props.players}>
+        {(player) => (
+          <article class="rounded-3xl border border-white/10 bg-(--color-surface) p-4">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="text-sm font-semibold text-(--color-fg)">{player.name}</p>
+                <p class="text-xs uppercase tracking-[0.2em] text-(--color-muted)">{props.t(`seats.${player.seat}`)}</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <label class="text-xs text-(--color-muted)" for={`call-${player.id}`}>
+                  {props.t('round.tichu')}
+                </label>
+                <select
+                  id={`call-${player.id}`}
+                  class={clsx(
+                    'rounded-full border border-white/10 bg-black/15 px-3 py-2',
+                    'text-sm text-(--color-fg) outline-none focus:border-(--color-accent)',
+                  )}
+                  value={props.draft.tichuCalls[player.id]}
+                  data-testid={`tichu-call-${player.id}`}
+                  onInput={(event) => props.onTichuCallChange(player.id, event.currentTarget.value as TichuCall)}
+                >
+                  <option value="none">{props.t('round.noCall')}</option>
+                  <option value="small">{props.t('round.small')}</option>
+                  <option value="grand">{props.t('round.grand')}</option>
+                </select>
+              </div>
+            </div>
+            <label class="mt-4 flex items-center gap-3 rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-(--color-fg)">
+              <input
+                type="radio"
+                name="first-out-player"
+                checked={props.draft.firstOutPlayerId === player.id}
+                data-testid={`first-out-${player.id}`}
+                onChange={() => props.onFirstOutChange(player.id)}
+              />
+              <span>{props.t('round.firstOut')}</span>
+            </label>
+          </article>
+        )}
+      </For>
+    </div>
+  )
+}

--- a/src/features/rounds/round-entry.shared.ts
+++ b/src/features/rounds/round-entry.shared.ts
@@ -1,0 +1,54 @@
+import { createDefaultTichuCalls } from '@/domain/defaults'
+import type { Player, RoundInput, TeamId, TichuCall } from '@/domain/types'
+
+export type RoundDraft = {
+  firstOutPlayerId: Player['id']
+  doubleVictoryTeamId: TeamId | ''
+  cardPointsNorthSouth: string
+  cardPointsEastWest: string
+  tichuCalls: Record<Player['id'], TichuCall>
+}
+
+export function createDraft(players: Player[]): RoundDraft {
+  return {
+    firstOutPlayerId: players[0]?.id ?? 'player-1',
+    doubleVictoryTeamId: '',
+    cardPointsNorthSouth: '50',
+    cardPointsEastWest: '50',
+    tichuCalls: createDefaultTichuCalls(),
+  }
+}
+
+export function createDraftFromRound(input: RoundInput): RoundDraft {
+  return {
+    firstOutPlayerId: input.firstOutPlayerId,
+    doubleVictoryTeamId: input.doubleVictoryTeamId ?? '',
+    cardPointsNorthSouth: input.cardPoints ? String(input.cardPoints['north-south']) : '50',
+    cardPointsEastWest: input.cardPoints ? String(input.cardPoints['east-west']) : '50',
+    tichuCalls: { ...input.tichuCalls },
+  }
+}
+
+export function buildRoundInput(draft: RoundDraft): RoundInput {
+  const doubleVictoryTeamId = draft.doubleVictoryTeamId || null
+
+  return {
+    firstOutPlayerId: draft.firstOutPlayerId,
+    doubleVictoryTeamId,
+    tichuCalls: { ...draft.tichuCalls },
+    cardPoints: doubleVictoryTeamId
+      ? null
+      : {
+          'north-south': Number(draft.cardPointsNorthSouth || 0),
+          'east-west': Number(draft.cardPointsEastWest || 0),
+        },
+  }
+}
+
+export function formatElapsedMs(value: number) {
+  const totalSeconds = Math.max(0, Math.floor(value / 1000))
+  const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0')
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+
+  return `${minutes}:${seconds}`
+}


### PR DESCRIPTION
## Summary
- split RoundEntry into focused player-list, meta-fields, and shared draft helper modules
- reduce RoundEntry.tsx below the 300-line target
- keep round entry behavior and validation unchanged while establishing the next file-length refactor slice

Closes #60