### PR TITLE
refactor: split the game context

### DIFF
--- a/src/state/game-context-actions.ts
+++ b/src/state/game-context-actions.ts
@@ -1,0 +1,159 @@
+import { reconcile, unwrap, type SetStoreFunction, type Store } from 'solid-js/store'
+import { mergeRecentPlayerNames } from '@/domain/defaults'
+import type {
+  PersistedGameState,
+  Player,
+  PlayerId,
+} from '@/domain/types'
+import { clearGameState } from '@/storage/game-storage'
+import {
+  applyLanguageTeamNameDefaults,
+  createResetState,
+  createRoundRecord,
+  type GameContextValue,
+} from './game-context.shared'
+
+type CreateGameActionsOptions = {
+  state: Store<PersistedGameState>
+  setState: SetStoreFunction<PersistedGameState>
+}
+
+export function createGameActions(options: CreateGameActionsOptions): Pick<
+  GameContextValue,
+  | 'startGame'
+  | 'updatePlayerName'
+  | 'assignPlayerSeat'
+  | 'swapPlayerSeats'
+  | 'setTeamColor'
+  | 'setTeamName'
+  | 'setLanguage'
+  | 'setTheme'
+  | 'startRound'
+  | 'cancelActiveRound'
+  | 'addRound'
+  | 'updateRound'
+  | 'deleteRound'
+  | 'duplicateRound'
+  | 'findRound'
+  | 'resetGame'
+> {
+  const { state, setState } = options
+
+  return {
+    startGame: () => setState('hasStartedGame', true),
+    updatePlayerName: (playerId, name) => {
+      const trimmedName = name.trimStart().slice(0, 24)
+      const previousName = state.players.find((player) => player.id === playerId)?.name
+
+      setState('players', (player) => player.id === playerId, 'name', (currentName) => trimmedName || currentName)
+
+      if (previousName && trimmedName && previousName !== trimmedName) {
+        setState('recentPlayerNames', (names) => mergeRecentPlayerNames(names, [previousName]))
+      }
+    },
+    assignPlayerSeat: (playerId, seat) => {
+      const sourcePlayer = state.players.find((player) => player.id === playerId)
+      const targetPlayer = state.players.find((player) => player.seat === seat)
+
+      if (!sourcePlayer || !targetPlayer || sourcePlayer.seat === seat) {
+        return
+      }
+
+      setState('players', mapPlayersBySeatSwap(state.players, sourcePlayer.id, targetPlayer.id))
+    },
+    swapPlayerSeats: (sourcePlayerId, targetPlayerId) => {
+      if (sourcePlayerId === targetPlayerId) {
+        return
+      }
+
+      const sourcePlayer = state.players.find((player) => player.id === sourcePlayerId)
+      const targetPlayer = state.players.find((player) => player.id === targetPlayerId)
+
+      if (!sourcePlayer || !targetPlayer) {
+        return
+      }
+
+      setState('players', mapPlayersBySeatSwap(state.players, sourcePlayer.id, targetPlayer.id))
+    },
+    setTeamColor: (teamId, color) => {
+      const oppositeTeamId = teamId === 'north-south' ? 'east-west' : 'north-south'
+
+      if (state.settings.teamColors[oppositeTeamId] === color) {
+        return
+      }
+
+      setState('settings', 'teamColors', teamId, color)
+    },
+    setTeamName: (teamId, name) =>
+      setState('settings', 'teamNames', teamId, name.trim().slice(0, 24) || state.settings.teamNames[teamId]),
+    setLanguage: (language) =>
+      setState('settings', (current) => ({
+        ...current,
+        language,
+        teamNames: applyLanguageTeamNameDefaults(current.teamNames, state.settings.language, language),
+      })),
+    setTheme: (theme) => setState('settings', 'theme', theme),
+    startRound: () => {
+      if (!state.activeRoundStartedAt) {
+        setState('activeRoundStartedAt', new Date().toISOString())
+      }
+    },
+    cancelActiveRound: () => setState('activeRoundStartedAt', null),
+    addRound: (input) => {
+      const round = createRoundRecord(state.players, input, undefined, state.activeRoundStartedAt ?? undefined)
+      setState('rounds', (rounds) => [...rounds, round])
+      setState('activeRoundStartedAt', null)
+    },
+    updateRound: (roundId, input) => {
+      const existingRound = state.rounds.find((item) => item.id === roundId)
+
+      if (!existingRound) {
+        return
+      }
+
+      const round = createRoundRecord(
+        state.players,
+        input,
+        roundId,
+        existingRound.timing.startedAt,
+        existingRound.timing.completedAt,
+      )
+
+      setState('rounds', state.rounds.map((item) => (item.id === roundId ? round : item)))
+    },
+    deleteRound: (roundId) => setState('rounds', state.rounds.filter((round) => round.id !== roundId)),
+    duplicateRound: (roundId) => {
+      const round = state.rounds.find((item) => item.id === roundId)
+
+      if (round) {
+        setState('rounds', (rounds) => [...rounds, createRoundRecord(state.players, round.input)])
+      }
+    },
+    findRound: (roundId) => state.rounds.find((round) => round.id === roundId),
+    resetGame: () => {
+      clearGameState(window.localStorage)
+      setState(reconcile(createResetState(unwrap(state))))
+    },
+  }
+}
+
+function mapPlayersBySeatSwap(players: Player[], sourcePlayerId: PlayerId, targetPlayerId: PlayerId) {
+  const sourcePlayer = players.find((player) => player.id === sourcePlayerId)
+  const targetPlayer = players.find((player) => player.id === targetPlayerId)
+
+  if (!sourcePlayer || !targetPlayer) {
+    return players
+  }
+
+  return players.map((player) => {
+    if (player.id === sourcePlayerId) {
+      return { ...player, seat: targetPlayer.seat }
+    }
+
+    if (player.id === targetPlayerId) {
+      return { ...player, seat: sourcePlayer.seat }
+    }
+
+    return player
+  })
+}

--- a/src/state/game-context.shared.ts
+++ b/src/state/game-context.shared.ts
@@ -1,0 +1,145 @@
+import { createDefaultPlayers, createDefaultTeamNames, mergeRecentPlayerNames } from '@/domain/defaults'
+import { getTeamIdBySeat } from '@/domain/helpers'
+import {
+  calculateCumulativeScores,
+  calculateRoundScore,
+  getGameStatus,
+  getLeadingTeamId,
+} from '@/domain/scoring'
+import type {
+  PersistedGameState,
+  Player,
+  PlayerId,
+  RoundInput,
+  RoundRecord,
+  Seat,
+  TeamColor,
+  TeamId,
+  ThemeMode,
+} from '@/domain/types'
+import { createInitialGameState, loadGameState } from '@/storage/game-storage'
+import type { TranslationKey } from '@/shared/i18n'
+
+export type GameContextValue = {
+  state: PersistedGameState
+  cumulativeScores: () => ReturnType<typeof calculateCumulativeScores>
+  gameStatus: () => ReturnType<typeof getGameStatus>
+  leadingTeamId: () => ReturnType<typeof getLeadingTeamId>
+  teamNames: () => Record<TeamId, string>
+  teamLineups: () => Record<TeamId, string>
+  systemTheme: () => Exclude<ThemeMode, 'system'>
+  effectiveTheme: () => Exclude<ThemeMode, 'system'>
+  t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
+  startGame: () => void
+  updatePlayerName: (playerId: PlayerId, name: string) => void
+  assignPlayerSeat: (playerId: PlayerId, seat: Seat) => void
+  swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
+  setTeamColor: (teamId: TeamId, color: TeamColor) => void
+  setTeamName: (teamId: TeamId, name: string) => void
+  setLanguage: (language: PersistedGameState['settings']['language']) => void
+  setTheme: (theme: ThemeMode) => void
+  addRound: (input: RoundInput) => void
+  updateRound: (roundId: string, input: RoundInput) => void
+  startRound: () => void
+  cancelActiveRound: () => void
+  deleteRound: (roundId: string) => void
+  duplicateRound: (roundId: string) => void
+  findRound: (roundId: string) => RoundRecord | undefined
+  resetGame: () => void
+}
+
+export function loadInitialState() {
+  if (typeof window === 'undefined') {
+    return createInitialGameState()
+  }
+
+  return loadGameState(window.localStorage)
+}
+
+export function detectSystemTheme(): Exclude<ThemeMode, 'system'> {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'dark'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function createRoundRecord(
+  players: Player[],
+  input: RoundInput,
+  roundId = createRoundId(),
+  startedAt = new Date().toISOString(),
+  completedAt = new Date().toISOString(),
+): RoundRecord {
+  const elapsedMs = Math.max(0, new Date(completedAt).getTime() - new Date(startedAt).getTime())
+
+  return {
+    id: roundId,
+    input,
+    result: calculateRoundScore(players, input),
+    timing: {
+      startedAt,
+      completedAt,
+      elapsedMs,
+    },
+  }
+}
+
+export function createRoundId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `round-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function createTeamLineups(players: Player[]) {
+  const names = {
+    'north-south': [] as string[],
+    'east-west': [] as string[],
+  }
+
+  for (const player of players) {
+    names[getTeamIdBySeat(player.seat)].push(player.name)
+  }
+
+  return {
+    'north-south': names['north-south'].join(' / '),
+    'east-west': names['east-west'].join(' / '),
+  }
+}
+
+export function applyLanguageTeamNameDefaults(
+  currentNames: Record<TeamId, string>,
+  previousLanguage: PersistedGameState['settings']['language'],
+  nextLanguage: PersistedGameState['settings']['language'],
+) {
+  const previousDefaults = createDefaultTeamNames(previousLanguage)
+  const nextDefaults = createDefaultTeamNames(nextLanguage)
+
+  return {
+    'north-south':
+      currentNames['north-south'] === previousDefaults['north-south']
+        ? nextDefaults['north-south']
+        : currentNames['north-south'],
+    'east-west':
+      currentNames['east-west'] === previousDefaults['east-west']
+        ? nextDefaults['east-west']
+        : currentNames['east-west'],
+  }
+}
+
+export function createResetState(state: PersistedGameState) {
+  const recentPlayerNames = mergeRecentPlayerNames(
+    state.recentPlayerNames,
+    state.players.map((player) => player.name.trim()).filter(Boolean),
+  )
+
+  return {
+    ...createInitialGameState(),
+    players: createDefaultPlayers(),
+    activeRoundStartedAt: null,
+    recentPlayerNames,
+    settings: state.settings,
+  }
+}

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -7,93 +7,31 @@ import {
   useContext,
   type ParentComponent,
 } from 'solid-js'
-import { createStore, reconcile, unwrap } from 'solid-js/store'
-import { createDefaultPlayers, createDefaultTeamNames, mergeRecentPlayerNames } from '@/domain/defaults'
-import { getTeamIdBySeat } from '@/domain/helpers'
+import { createStore, unwrap } from 'solid-js/store'
+import { calculateCumulativeScores, getGameStatus, getLeadingTeamId } from '@/domain/scoring'
+import { saveGameState } from '@/storage/game-storage'
+import { createTranslator } from '@/shared/i18n'
+import { createGameActions } from './game-context-actions'
 import {
-  calculateCumulativeScores,
-  calculateRoundScore,
-  getGameStatus,
-  getLeadingTeamId,
-} from '@/domain/scoring'
-import type {
-  PersistedGameState,
-  Player,
-  PlayerId,
-  RoundInput,
-  RoundRecord,
-  Seat,
-  TeamColor,
-  TeamId,
-  ThemeMode,
-} from '@/domain/types'
-import {
-  clearGameState,
-  createInitialGameState,
-  loadGameState,
-  saveGameState,
-} from '@/storage/game-storage'
-import { createTranslator, type TranslationKey } from '@/shared/i18n'
-
-type GameContextValue = {
-  state: PersistedGameState
-  cumulativeScores: () => ReturnType<typeof calculateCumulativeScores>
-  gameStatus: () => ReturnType<typeof getGameStatus>
-  leadingTeamId: () => ReturnType<typeof getLeadingTeamId>
-  teamNames: () => Record<TeamId, string>
-  teamLineups: () => Record<TeamId, string>
-  systemTheme: () => Exclude<ThemeMode, 'system'>
-  effectiveTheme: () => Exclude<ThemeMode, 'system'>
-  t: (key: TranslationKey, args?: Record<string, string | number | boolean>) => string
-  startGame: () => void
-  updatePlayerName: (playerId: PlayerId, name: string) => void
-  assignPlayerSeat: (playerId: PlayerId, seat: Seat) => void
-  swapPlayerSeats: (sourcePlayerId: PlayerId, targetPlayerId: PlayerId) => void
-  setTeamColor: (teamId: TeamId, color: TeamColor) => void
-  setTeamName: (teamId: TeamId, name: string) => void
-  setLanguage: (language: PersistedGameState['settings']['language']) => void
-  setTheme: (theme: ThemeMode) => void
-  addRound: (input: RoundInput) => void
-  updateRound: (roundId: string, input: RoundInput) => void
-  startRound: () => void
-  cancelActiveRound: () => void
-  deleteRound: (roundId: string) => void
-  duplicateRound: (roundId: string) => void
-  findRound: (roundId: string) => RoundRecord | undefined
-  resetGame: () => void
-}
+  createTeamLineups,
+  detectSystemTheme,
+  type GameContextValue,
+  loadInitialState,
+} from './game-context.shared'
 
 const GameContext = createContext<GameContextValue>()
 
 export const GameProvider: ParentComponent = (props) => {
-  const [systemTheme, setSystemTheme] = createSignal<Exclude<ThemeMode, 'system'>>(detectSystemTheme())
-  const [state, setState] = createStore<PersistedGameState>(loadInitialState())
+  const [systemTheme, setSystemTheme] = createSignal(detectSystemTheme())
+  const [state, setState] = createStore(loadInitialState())
 
   const translate = createMemo(() => createTranslator(state.settings.language))
-  const cumulativeScores = createMemo(() =>
-    calculateCumulativeScores(state.rounds.map((round) => round.result)),
-  )
+  const cumulativeScores = createMemo(() => calculateCumulativeScores(state.rounds.map((round) => round.result)))
   const gameStatus = createMemo(() => getGameStatus(cumulativeScores()))
   const leadingTeamId = createMemo(() => getLeadingTeamId(cumulativeScores()))
-  const teamLineups = createMemo(() => {
-    const names = {
-      'north-south': [] as string[],
-      'east-west': [] as string[],
-    }
-
-    for (const player of state.players) {
-      names[getTeamIdBySeat(player.seat)].push(player.name)
-    }
-
-    return {
-      'north-south': names['north-south'].join(' / '),
-      'east-west': names['east-west'].join(' / '),
-    }
-  })
+  const teamLineups = createMemo(() => createTeamLineups(state.players))
   const teamNames = createMemo(() => state.settings.teamNames)
-  const effectiveTheme = createMemo<Exclude<ThemeMode, 'system'>>(() =>
-    state.settings.theme === 'system' ? systemTheme() : state.settings.theme,
-  )
+  const effectiveTheme = createMemo(() => (state.settings.theme === 'system' ? systemTheme() : state.settings.theme))
 
   const mediaQuery =
     typeof window !== 'undefined' && typeof window.matchMedia === 'function'
@@ -101,10 +39,7 @@ export const GameProvider: ParentComponent = (props) => {
       : null
 
   if (mediaQuery) {
-    const handleChange = (event: MediaQueryListEvent) => {
-      setSystemTheme(event.matches ? 'dark' : 'light')
-    }
-
+    const handleChange = (event: MediaQueryListEvent) => setSystemTheme(event.matches ? 'dark' : 'light')
     setSystemTheme(mediaQuery.matches ? 'dark' : 'light')
     mediaQuery.addEventListener('change', handleChange)
     onCleanup(() => mediaQuery.removeEventListener('change', handleChange))
@@ -119,6 +54,8 @@ export const GameProvider: ParentComponent = (props) => {
     document.documentElement.lang = state.settings.language
   })
 
+  const actions = createGameActions({ state, setState })
+
   const value: GameContextValue = {
     state,
     cumulativeScores,
@@ -129,177 +66,7 @@ export const GameProvider: ParentComponent = (props) => {
     systemTheme,
     effectiveTheme,
     t: (key, args) => translate()(key, args),
-    startGame: () => setState('hasStartedGame', true),
-    updatePlayerName: (playerId, name) => {
-      const trimmedName = name.trimStart().slice(0, 24)
-      const previousName = state.players.find((player) => player.id === playerId)?.name
-
-      setState(
-        'players',
-        (player) => player.id === playerId,
-        'name',
-        (currentName) => trimmedName || currentName,
-      )
-
-      if (previousName && trimmedName && previousName !== trimmedName) {
-        setState('recentPlayerNames', (names) => mergeRecentPlayerNames(names, [previousName]))
-      }
-    },
-    assignPlayerSeat: (playerId, seat) => {
-      const sourcePlayer = state.players.find((player) => player.id === playerId)
-      const targetPlayer = state.players.find((player) => player.seat === seat)
-
-      if (!sourcePlayer || !targetPlayer || sourcePlayer.seat === seat) {
-        return
-      }
-
-      setState(
-        'players',
-        state.players.map((player) => {
-          if (player.id === playerId) {
-            return { ...player, seat }
-          }
-
-          if (player.id === targetPlayer.id) {
-            return { ...player, seat: sourcePlayer.seat }
-          }
-
-          return player
-        }),
-      )
-    },
-    swapPlayerSeats: (sourcePlayerId, targetPlayerId) => {
-      if (sourcePlayerId === targetPlayerId) {
-        return
-      }
-
-      const sourcePlayer = state.players.find((player) => player.id === sourcePlayerId)
-      const targetPlayer = state.players.find((player) => player.id === targetPlayerId)
-
-      if (!sourcePlayer || !targetPlayer) {
-        return
-      }
-
-      setState(
-        'players',
-        state.players.map((player) => {
-          if (player.id === sourcePlayerId) {
-            return { ...player, seat: targetPlayer.seat }
-          }
-
-          if (player.id === targetPlayerId) {
-            return { ...player, seat: sourcePlayer.seat }
-          }
-
-          return player
-        }),
-      )
-    },
-    setTeamColor: (teamId, color) => {
-      const oppositeTeamId: TeamId = teamId === 'north-south' ? 'east-west' : 'north-south'
-
-      if (state.settings.teamColors[oppositeTeamId] === color) {
-        return
-      }
-
-      setState('settings', 'teamColors', teamId, color)
-    },
-    setTeamName: (teamId, name) =>
-      setState('settings', 'teamNames', teamId, name.trim().slice(0, 24) || state.settings.teamNames[teamId]),
-    setLanguage: (language) => {
-      const previousDefaults = createDefaultTeamNames(state.settings.language)
-      const nextDefaults = createDefaultTeamNames(language)
-
-      setState('settings', (current) => ({
-        ...current,
-        language,
-        teamNames: {
-          'north-south':
-            current.teamNames['north-south'] === previousDefaults['north-south']
-              ? nextDefaults['north-south']
-              : current.teamNames['north-south'],
-          'east-west':
-            current.teamNames['east-west'] === previousDefaults['east-west']
-              ? nextDefaults['east-west']
-              : current.teamNames['east-west'],
-        },
-      }))
-    },
-    setTheme: (theme) => setState('settings', 'theme', theme),
-    startRound: () => {
-      if (state.activeRoundStartedAt) {
-        return
-      }
-
-      setState('activeRoundStartedAt', new Date().toISOString())
-    },
-    cancelActiveRound: () => setState('activeRoundStartedAt', null),
-    addRound: (input) => {
-      const round = createRoundRecord(
-        state.players,
-        input,
-        undefined,
-        state.activeRoundStartedAt ?? undefined,
-      )
-      setState('rounds', (rounds) => [...rounds, round])
-      setState('activeRoundStartedAt', null)
-    },
-    updateRound: (roundId, input) => {
-      const existingRound = state.rounds.find((item) => item.id === roundId)
-
-      if (!existingRound) {
-        return
-      }
-
-      const round = createRoundRecord(
-        state.players,
-        input,
-        roundId,
-        existingRound.timing.startedAt,
-        existingRound.timing.completedAt,
-      )
-      setState(
-        'rounds',
-        state.rounds.map((item) => (item.id === roundId ? round : item)),
-      )
-    },
-    deleteRound: (roundId) => {
-      setState(
-        'rounds',
-        state.rounds.filter((round) => round.id !== roundId),
-      )
-    },
-    duplicateRound: (roundId) => {
-      const round = state.rounds.find((item) => item.id === roundId)
-
-      if (!round) {
-        return
-      }
-
-      setState('rounds', (rounds) => [
-        ...rounds,
-        createRoundRecord(state.players, round.input),
-      ])
-    },
-    findRound: (roundId) => state.rounds.find((round) => round.id === roundId),
-    resetGame: () => {
-      const recentPlayerNames = mergeRecentPlayerNames(
-        state.recentPlayerNames,
-        state.players.map((player) => player.name.trim()).filter(Boolean),
-      )
-      const nextSettings = unwrap(state.settings)
-
-      clearGameState(window.localStorage)
-      setState(
-        reconcile({
-          ...createInitialGameState(),
-          players: createDefaultPlayers(),
-          activeRoundStartedAt: null,
-          recentPlayerNames,
-          settings: nextSettings,
-        }),
-      )
-    },
+    ...actions,
   }
 
   return <GameContext.Provider value={value}>{props.children}</GameContext.Provider>
@@ -313,49 +80,4 @@ export function useGame() {
   }
 
   return context
-}
-
-function loadInitialState() {
-  if (typeof window === 'undefined') {
-    return createInitialGameState()
-  }
-
-  return loadGameState(window.localStorage)
-}
-
-function detectSystemTheme(): Exclude<ThemeMode, 'system'> {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return 'dark'
-  }
-
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-}
-
-function createRoundRecord(
-  players: Player[],
-  input: RoundInput,
-  roundId = createRoundId(),
-  startedAt = new Date().toISOString(),
-  completedAt = new Date().toISOString(),
-): RoundRecord {
-  const elapsedMs = Math.max(0, new Date(completedAt).getTime() - new Date(startedAt).getTime())
-
-  return {
-    id: roundId,
-    input,
-    result: calculateRoundScore(players, input),
-    timing: {
-      startedAt,
-      completedAt,
-      elapsedMs,
-    },
-  }
-}
-
-function createRoundId() {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
-  }
-
-  return `round-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }


### PR DESCRIPTION
## Summary
- split game-context provider logic into shared helpers and action creators
- keep the provider focused on derived state and effects
- reduce the main game-context file below the file length target

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #61