### PR TITLE
refactor: split app shell navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,14 @@ import { Show, createEffect, createSignal, onCleanup, onMount } from 'solid-js'
 import { ApplicationControlBar } from '@/features/app/ApplicationControlBar'
 import { GameTabBar } from '@/features/app/GameTabBar'
 import { GameplayPages } from '@/features/app/GameplayPages'
+import { useAppNavigation } from '@/features/app/use-app-navigation'
+import { useSwipeNavigation } from '@/features/app/use-swipe-navigation'
 import { LandingScreen } from '@/features/landing/LandingScreen'
 import { GlobalScoreSummary } from '@/features/scoreboard/Scoreboard'
 import { SettingsDialog } from '@/features/settings/SettingsDialog'
 import { GameProvider, useGame } from '@/state/game-context'
 import {
-  getAdjacentRoute,
   getDefaultRoute,
-  getHashForRoute,
-  getRouteFromHash,
-  isInGameRoute,
-  type AppRoute,
   type InGameRoute,
 } from '@/shared/routes'
 
@@ -20,80 +17,18 @@ function AppContent() {
   const { state } = useGame()
   const [editingRoundId, setEditingRoundId] = createSignal<string | null>(null)
   const [isSettingsOpen, setIsSettingsOpen] = createSignal(false)
-  const [route, setRoute] = createSignal<AppRoute>(resolveInitialRoute(state.hasStartedGame))
+  const { route, navigate, syncRouteFromLocation } = useAppNavigation(() => state.hasStartedGame)
   const currentGameRoute = (): InGameRoute => (route() === 'start' ? 'party' : route()) as InGameRoute
 
-  let touchStartX = 0
-  let touchStartY = 0
-  let swipeEnabled = false
-
-  const syncRouteFromLocation = () => {
-    setRoute(getRouteFromHash(window.location.hash, state.hasStartedGame))
-  }
-
-  const navigate = (nextRoute: AppRoute, options?: { replace?: boolean }) => {
-    const nextHash = getHashForRoute(nextRoute)
-
-    if (window.location.hash !== nextHash) {
-      if (options?.replace) {
-        window.history.replaceState(null, '', nextHash)
-      } else {
-        window.history.pushState(null, '', nextHash)
-      }
-    }
-
-    setRoute(nextRoute)
-  }
-
-  const handleSwipeStart = (event: TouchEvent) => {
-    const target = event.target
-
-    swipeEnabled =
-      target instanceof HTMLElement &&
-      !target.closest('button, input, select, textarea, label, a, [role="dialog"]')
-
-    if (!swipeEnabled) {
-      return
-    }
-
-    touchStartX = event.changedTouches[0]?.clientX ?? 0
-    touchStartY = event.changedTouches[0]?.clientY ?? 0
-  }
-
-  const handleSwipeEnd = (event: TouchEvent) => {
-    if (!swipeEnabled || !isInGameRoute(route())) {
-      return
-    }
-
-    const touch = event.changedTouches[0]
-
-    if (!touch) {
-      return
-    }
-
-    const deltaX = touch.clientX - touchStartX
-    const deltaY = touch.clientY - touchStartY
-
-    swipeEnabled = false
-
-    if (Math.abs(deltaX) < 56 || Math.abs(deltaX) < Math.abs(deltaY) * 1.2) {
-      return
-    }
-
-    navigate(getAdjacentRoute(currentGameRoute(), deltaX < 0 ? 'next' : 'previous'))
-  }
+  useSwipeNavigation({ route, currentGameRoute, navigate: (nextRoute) => navigate(nextRoute) })
 
   onMount(() => {
     syncRouteFromLocation()
     window.addEventListener('hashchange', syncRouteFromLocation)
-    window.addEventListener('touchstart', handleSwipeStart, { passive: true })
-    window.addEventListener('touchend', handleSwipeEnd, { passive: true })
   })
 
   onCleanup(() => {
     window.removeEventListener('hashchange', syncRouteFromLocation)
-    window.removeEventListener('touchstart', handleSwipeStart)
-    window.removeEventListener('touchend', handleSwipeEnd)
   })
 
   createEffect(() => {
@@ -147,14 +82,6 @@ function App() {
       <AppContent />
     </GameProvider>
   )
-}
-
-function resolveInitialRoute(hasStartedGame: boolean): AppRoute {
-  if (typeof window === 'undefined') {
-    return getDefaultRoute(hasStartedGame)
-  }
-
-  return getRouteFromHash(window.location.hash, hasStartedGame)
 }
 
 export default App

--- a/src/features/app/use-app-navigation.ts
+++ b/src/features/app/use-app-navigation.ts
@@ -1,0 +1,44 @@
+import { createSignal } from 'solid-js'
+import type { PersistedGameState } from '@/domain/types'
+import {
+  getDefaultRoute,
+  getHashForRoute,
+  getRouteFromHash,
+  type AppRoute,
+} from '@/shared/routes'
+
+export function useAppNavigation(hasStartedGame: () => PersistedGameState['hasStartedGame']) {
+  const [route, setRoute] = createSignal<AppRoute>(resolveInitialRoute(hasStartedGame()))
+
+  const syncRouteFromLocation = () => {
+    setRoute(getRouteFromHash(window.location.hash, hasStartedGame()))
+  }
+
+  const navigate = (nextRoute: AppRoute, options?: { replace?: boolean }) => {
+    const nextHash = getHashForRoute(nextRoute)
+
+    if (window.location.hash !== nextHash) {
+      if (options?.replace) {
+        window.history.replaceState(null, '', nextHash)
+      } else {
+        window.history.pushState(null, '', nextHash)
+      }
+    }
+
+    setRoute(nextRoute)
+  }
+
+  return {
+    route,
+    navigate,
+    syncRouteFromLocation,
+  }
+}
+
+function resolveInitialRoute(hasStartedGame: boolean): AppRoute {
+  if (typeof window === 'undefined') {
+    return getDefaultRoute(hasStartedGame)
+  }
+
+  return getRouteFromHash(window.location.hash, hasStartedGame)
+}

--- a/src/features/app/use-swipe-navigation.ts
+++ b/src/features/app/use-swipe-navigation.ts
@@ -1,0 +1,67 @@
+import { onCleanup, onMount, type Accessor } from 'solid-js'
+import {
+  getAdjacentRoute,
+  isInGameRoute,
+  type AppRoute,
+  type InGameRoute,
+} from '@/shared/routes'
+
+type UseSwipeNavigationOptions = {
+  route: Accessor<AppRoute>
+  currentGameRoute: Accessor<InGameRoute>
+  navigate: (route: AppRoute) => void
+}
+
+export function useSwipeNavigation(options: UseSwipeNavigationOptions) {
+  let touchStartX = 0
+  let touchStartY = 0
+  let swipeEnabled = false
+
+  const handleSwipeStart = (event: TouchEvent) => {
+    const target = event.target
+
+    swipeEnabled =
+      target instanceof HTMLElement &&
+      !target.closest('button, input, select, textarea, label, a, [role="dialog"]')
+
+    if (!swipeEnabled) {
+      return
+    }
+
+    touchStartX = event.changedTouches[0]?.clientX ?? 0
+    touchStartY = event.changedTouches[0]?.clientY ?? 0
+  }
+
+  const handleSwipeEnd = (event: TouchEvent) => {
+    if (!swipeEnabled || !isInGameRoute(options.route())) {
+      return
+    }
+
+    const touch = event.changedTouches[0]
+
+    if (!touch) {
+      return
+    }
+
+    const deltaX = touch.clientX - touchStartX
+    const deltaY = touch.clientY - touchStartY
+
+    swipeEnabled = false
+
+    if (Math.abs(deltaX) < 56 || Math.abs(deltaX) < Math.abs(deltaY) * 1.2) {
+      return
+    }
+
+    options.navigate(getAdjacentRoute(options.currentGameRoute(), deltaX < 0 ? 'next' : 'previous'))
+  }
+
+  onMount(() => {
+    window.addEventListener('touchstart', handleSwipeStart, { passive: true })
+    window.addEventListener('touchend', handleSwipeEnd, { passive: true })
+  })
+
+  onCleanup(() => {
+    window.removeEventListener('touchstart', handleSwipeStart)
+    window.removeEventListener('touchend', handleSwipeEnd)
+  })
+}


### PR DESCRIPTION
## Summary
- extract route and hash synchronization into a dedicated app navigation helper
- extract swipe gesture setup into a dedicated helper
- keep App focused on provider composition and screen layout

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #73