### PR TITLE
fix: keep the landing route in sync with the hash

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,7 @@ describe('App', () => {
 
     expect(screen.getByRole('heading', { name: /tichuboard/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /start scoring/i })).toBeInTheDocument()
+    expect(window.location.hash).toBe('#/start')
   })
 
   it('enters the scoring screen after pressing start', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { SettingsDialog } from '@/features/settings/SettingsDialog'
 import { GameProvider, useGame } from '@/state/game-context'
 import {
   getDefaultRoute,
+  getHashForRoute,
   type InGameRoute,
 } from '@/shared/routes'
 
@@ -34,6 +35,18 @@ function AppContent() {
   createEffect(() => {
     if (!state.hasStartedGame && route() !== 'start') {
       navigate('start', { replace: true })
+    }
+  })
+
+  createEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const expectedHash = getHashForRoute(route())
+
+    if (window.location.hash !== expectedHash) {
+      navigate(route(), { replace: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- keep the landing screen explicitly addressable as 
- normalize the URL hash to the active route after initial render and route changes
- add an app test that locks the initial landing hash behavior

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #80