### PR TITLE
fix: lock the landing shell to the viewport

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -16,6 +16,7 @@ describe('App', () => {
     expect(window.location.hash).toBe('#/start')
     expect(screen.getByTestId('landing-layout')).toBeInTheDocument()
     expect(screen.getByTestId('landing-content').className).toContain('overflow-y-auto')
+    expect(screen.getByTestId('app-shell').className).toContain('overflow-hidden')
   })
 
   it('enters the scoring screen after pressing start', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { Show, createEffect, createSignal, onCleanup, onMount } from 'solid-js'
 import { ApplicationControlBar } from '@/features/app/ApplicationControlBar'
 import { GameTabBar } from '@/features/app/GameTabBar'
@@ -20,6 +21,7 @@ function AppContent() {
   const [isSettingsOpen, setIsSettingsOpen] = createSignal(false)
   const { route, navigate, syncRouteFromLocation } = useAppNavigation(() => state.hasStartedGame)
   const currentGameRoute = (): InGameRoute => (route() === 'start' ? 'party' : route()) as InGameRoute
+  const isStartRoute = () => route() === 'start'
 
   useSwipeNavigation({ route, currentGameRoute, navigate: (nextRoute) => navigate(nextRoute) })
 
@@ -51,10 +53,23 @@ function AppContent() {
   })
 
   return (
-    <main class="min-h-screen bg-(--color-bg) text-(--color-fg)">
-      <section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-6 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:py-8 lg:px-8">
+    <main
+      class={clsx(
+        'bg-(--color-bg) text-(--color-fg)',
+        isStartRoute() ? 'h-dvh overflow-hidden' : 'min-h-screen',
+      )}
+      data-testid="app-shell"
+    >
+      <section
+        class={clsx(
+          'mx-auto flex w-full max-w-6xl flex-col px-4 sm:px-6 lg:px-8',
+          isStartRoute()
+            ? 'h-dvh overflow-hidden py-4 sm:py-5'
+            : 'min-h-screen gap-4 py-6 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:py-8',
+        )}
+      >
         <Show
-          when={route() !== 'start'}
+          when={!isStartRoute()}
           fallback={<LandingScreen onEnterGame={() => navigate(getDefaultRoute(true))} />}
         >
           <ApplicationControlBar />


### PR DESCRIPTION
## Summary
- lock the outer app shell to the viewport while the start route is active
- prevent the landing screen from creating extra Y-axis scrolling outside the inner content area
- add an app test that checks the landing shell uses an overflow-hidden outer container

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #84