### PR TITLE
feat: polish party setup team controls

### DIFF
--- a/src/features/party-setup/PartyDialogPrimitives.tsx
+++ b/src/features/party-setup/PartyDialogPrimitives.tsx
@@ -24,11 +24,15 @@ export function DialogShell(props: ParentProps<{ closeLabel: string; onClose: ()
   )
 }
 
-export function DialogCloseButton(props: { closeLabel: string; onClose: () => void }) {
+export function DialogCloseButton(props: { closeLabel: string; onClose: () => void; size?: 'md' | 'lg' }) {
   return (
     <button
       type="button"
-      class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)"
+      class={
+        props.size === 'lg'
+          ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
+          : 'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
+      }
       aria-label={props.closeLabel}
       onClick={() => props.onClose()}
     >

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -41,13 +41,23 @@ describe('PartySetup', () => {
     await fireEvent.input(screen.getByTestId('team-editor-name-north-south'), {
       target: { value: 'Alpha Team' },
     })
+    await waitFor(() => {
+      expect(screen.getByTestId('team-label-north-south')).toHaveTextContent('Alpha Team')
+    })
     await fireEvent.click(screen.getByTestId('team-editor-color-violet'))
-    await fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('team-name-north-south').className).toContain('ring-violet-300/55')
+    })
 
     expect(screen.getByTestId('team-label-north-south')).toHaveTextContent('Alpha Team')
     expect(screen.getByTestId('team-name-north-south')).toHaveTextContent('Alpha Team')
+    expect(screen.getByTestId('team-name-north-south').className).toContain('ring-violet-300/55')
     expect(screen.getByTestId('bench-recent-Morgan')).toBeInTheDocument()
     expect(screen.getByTestId('bench-recent-Nova')).toBeInTheDocument()
+    expect(screen.getByTestId('team-editor-color-teal')).toBeInTheDocument()
+    expect(screen.getByTestId('team-editor-color-orange')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/team-editor-color-/)).toHaveLength(7)
+    await fireEvent.click(within(screen.getByTestId('team-editor-dialog')).getByText(/close team editor/i))
 
     const northSeat = screen.getByTestId('seat-north')
     await fireEvent.click(northSeat)
@@ -69,10 +79,11 @@ describe('PartySetup', () => {
     await fireEvent.click(screen.getByTestId('team-name-east-west'))
     expect(screen.getByTestId('team-editor-color-violet')).toBeDisabled()
     expect(screen.getByTestId('team-editor-color-amber')).not.toBeDisabled()
-    expect(screen.getByTestId('team-editor-color-teal')).toBeInTheDocument()
-    expect(screen.getByTestId('team-editor-color-orange')).toBeInTheDocument()
     await fireEvent.click(screen.getByTestId('team-editor-color-rose'))
-    await fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('team-name-east-west').className).toContain('ring-rose-300/55')
+    })
+    await fireEvent.click(within(screen.getByTestId('team-editor-dialog')).getByText(/close team editor/i))
 
     await waitFor(() => {
       expect(screen.getByTestId('team-name-east-west')).toHaveTextContent('Team 2')
@@ -103,6 +114,7 @@ describe('PartySetup', () => {
 
     expect(screen.getByTestId('team-editor-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('team-editor-dialog').className).toContain('max-h-dvh')
+    expect(within(screen.getByTestId('team-editor-dialog')).getByText(/close team editor/i)).toBeInTheDocument()
   })
 
   it('renders large seat overlays for every table target', async () => {

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -110,12 +110,9 @@ export function PartySetup() {
           closeLabel={controller.t('party.closeTeamEditor')}
           nameFieldLabel={controller.t('party.teamNameField')}
           teamColorsLabel={controller.t('party.teamColors')}
-          applyLabel={controller.t('party.applyChanges')}
-          cancelLabel={controller.t('round.cancel')}
           onNameInput={controller.setTeamEditorName}
           onColorSelect={controller.setTeamEditorColor}
           onClose={controller.closeTeamEditor}
-          onApply={controller.commitTeamEditor}
         />
       </Show>
     </section>

--- a/src/features/party-setup/TeamEditorDialog.tsx
+++ b/src/features/party-setup/TeamEditorDialog.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { For } from 'solid-js'
 import type { TeamColor } from '@/domain/types'
 import { teamColorClasses, teamColorOptions, type TeamEditorDraft } from './party-setup.shared'
-import { DialogActions, DialogCloseButton, DialogShell } from './PartyDialogPrimitives'
+import { DialogCloseButton, DialogShell } from './PartyDialogPrimitives'
 
 type TeamEditorDialogProps = {
   draft: TeamEditorDraft
@@ -12,12 +12,9 @@ type TeamEditorDialogProps = {
   closeLabel: string
   nameFieldLabel: string
   teamColorsLabel: string
-  applyLabel: string
-  cancelLabel: string
   onNameInput: (name: string) => void
   onColorSelect: (color: TeamColor) => void
   onClose: () => void
-  onApply: () => void
 }
 
 export function TeamEditorDialog(props: TeamEditorDialogProps) {
@@ -29,7 +26,7 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
             <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{props.title}</p>
             <p class="mt-2 text-sm text-(--color-muted)">{props.subtitle}</p>
           </div>
-          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} />
+          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} size="lg" />
         </div>
 
         <div class="mt-5 grid gap-5">
@@ -78,12 +75,15 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
         </div>
       </div>
 
-      <DialogActions
-        primaryLabel={props.applyLabel}
-        secondaryLabel={props.cancelLabel}
-        onPrimary={props.onApply}
-        onSecondary={props.onClose}
-      />
+      <div class="sticky bottom-0 border-t border-white/10 bg-[color-mix(in_srgb,var(--color-surface)_98%,#020617)] px-5 pb-[calc(env(safe-area-inset-bottom)+1.25rem)] pt-4 sm:px-5 sm:pb-5">
+        <button
+          type="button"
+          class="w-full rounded-2xl border border-white/10 px-4 py-3 text-sm text-(--color-fg)"
+          onClick={() => props.onClose()}
+        >
+          {props.closeLabel}
+        </button>
+      </div>
     </DialogShell>
   )
 }

--- a/src/features/party-setup/TeamSetupCard.tsx
+++ b/src/features/party-setup/TeamSetupCard.tsx
@@ -17,11 +17,20 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
   return (
     <button
       type="button"
-      class="rounded-3xl border border-white/10 bg-black/10 p-3 text-left transition-transform motion-safe:hover:-translate-y-0.5"
+      class={clsx(
+        'rounded-3xl border bg-black/10 p-3 text-left transition-transform motion-safe:hover:-translate-y-0.5',
+        teamColorClasses[props.selectedColor].ring,
+        teamColorClasses[props.selectedColor].glow,
+      )}
       data-testid={`team-name-${props.teamId}`}
       onClick={() => props.onOpenEditor(props.teamId)}
     >
-      <div class="grid gap-3">
+      <div
+        class={clsx(
+          'grid gap-3 rounded-[1.15rem] bg-linear-to-br p-1.5',
+          teamColorClasses[props.selectedColor].surface,
+        )}
+      >
         <div>
           <p class="text-sm font-medium text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
             {props.label}
@@ -29,13 +38,14 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
           <p class="mt-1 text-[11px] text-(--color-muted)">{props.subtitle}</p>
         </div>
         <div class="flex items-center justify-between gap-3">
-          <div class="flex flex-wrap gap-1.5">
-            <For each={teamColorOptions.slice(0, 4)}>
+          <div class="grid grid-cols-4 gap-1.5">
+            <For each={teamColorOptions}>
               {(color) => (
                 <span
                   class={clsx(
                     'h-3 w-3 rounded-full border border-white/10',
                     teamColorClasses[color].chip,
+                    props.selectedColor === color && 'scale-110 border-white/50',
                     props.selectedColor !== color && props.oppositeColor === color && 'opacity-25',
                   )}
                 />

--- a/src/features/party-setup/use-party-setup-controller.ts
+++ b/src/features/party-setup/use-party-setup-controller.ts
@@ -139,18 +139,6 @@ export function usePartySetupController() {
     closePlayerEditor()
   }
 
-  const commitTeamEditor = () => {
-    const draft = teamEditorDraft()
-
-    if (!draft) {
-      return
-    }
-
-    setTeamName(draft.teamId, draft.name)
-    setTeamColor(draft.teamId, draft.color)
-    setTeamEditorDraft(null)
-  }
-
   return {
     state,
     teamLineups,
@@ -174,9 +162,24 @@ export function usePartySetupController() {
     clearArmedState,
     activeTeamId: (teamId: TeamId) => (teamId === 'north-south' ? 'east-west' : 'north-south'),
     setEditorName: (name: string) => setEditorDraft((current) => (current ? { ...current, name } : current)),
-    setTeamEditorName: (name: string) => setTeamEditorDraft((current) => (current ? { ...current, name } : current)),
+    setTeamEditorName: (name: string) =>
+      setTeamEditorDraft((current) => {
+        if (!current) {
+          return current
+        }
+
+        setTeamName(current.teamId, name)
+        return { ...current, name }
+      }),
     setTeamEditorColor: (color: TeamEditorDraft['color']) =>
-      setTeamEditorDraft((current) => (current ? { ...current, color } : current)),
+      setTeamEditorDraft((current) => {
+        if (!current) {
+          return current
+        }
+
+        setTeamColor(current.teamId, color)
+        return { ...current, color }
+      }),
     armPlayer: (playerId: PlayerId) => {
       setArmedPlayerId(playerId)
       setArmedRecentName(null)
@@ -221,6 +224,5 @@ export function usePartySetupController() {
     closeTeamEditor: () => setTeamEditorDraft(null),
     handleSeatAssign,
     commitPlayerEditor,
-    commitTeamEditor,
   }
 }


### PR DESCRIPTION
## Summary
- apply the selected team color to the team setup card border and surface treatment
- show all seven team colors in the card and make team name and color changes apply immediately in the editor
- simplify the team editor controls to close-only and enlarge the top-right close button hit area

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #88