### PR TITLE
feat: redesign the team setup cards

### DIFF
--- a/docs/team-setup-card-requirements.md
+++ b/docs/team-setup-card-requirements.md
@@ -1,0 +1,63 @@
+# Team Setup Card Redesign Requirements
+
+## Context
+- Screen: `Party Setup`
+- Components in scope:
+  - `src/features/party-setup/TeamSetupCard.tsx`
+  - `src/features/party-setup/TeamEditorDialog.tsx`
+  - `src/features/party-setup/PartyDialogPrimitives.tsx`
+- Device target: mobile-first, especially iPhone 12 width (390px)
+
+## Current problems
+- The team card uses space inefficiently:
+  - team name, lineup, colors, and edit affordance do not form a strong visual hierarchy
+  - the lower color row feels detached from the main identity of the card
+- The close icon in the team editor is technically larger than before, but the icon glyph still reads too small
+- Team color changes apply immediately, but the dialog itself does not communicate the selected color strongly enough
+
+## Required outcomes
+1. Team cards should feel like compact identity cards for each team.
+2. The selected team color should define the card visually, not just appear as a small accent.
+3. The card should show:
+   - team name as the primary label
+   - lineup as the secondary label
+   - all 7 selectable colors in a compact but readable way
+   - a clear edit affordance
+4. The editor close affordance must be easy to hit with one thumb.
+5. The editor should visibly react to color selection at the dialog-chrome level, not only at the button level.
+
+## Layout guidance
+- Prefer a 2-zone team card:
+  - top: team identity and edit affordance
+  - bottom: condensed color palette plus active-color summary
+- Avoid wasting horizontal space with isolated tiny labels
+- Keep the card readable even when team names are customized
+- Preserve dark-mode contrast
+
+## Editor interaction guidance
+- Team name changes should remain immediate while typing
+- Team color selection should remain immediate on tap
+- The dialog background, border, accent strip, or header chip should visibly change with the current color
+- The footer should remain minimal:
+  - only one close action button
+
+## Non-goals
+- No change to scoring logic
+- No change to overall party setup flow
+- No change to how opposite-team color disabling works
+
+## Gemini feedback applied
+- Use a strong identity zone:
+  - larger team title
+  - quieter lineup text
+  - color row anchored as a separate lower zone
+- Show all 7 colors in one compact row with a clearer active ring
+- Make the selected color affect the full card identity:
+  - left accent border
+  - light surface tint
+- Make the team editor react at the chrome level:
+  - selected color should tint the dialog header area immediately
+- Make the close affordance larger:
+  - 48px touch target minimum
+  - visibly larger icon glyph
+- Avoid using saturated team colors as primary text colors in dark mode

--- a/src/features/party-setup/PartyDialogPrimitives.tsx
+++ b/src/features/party-setup/PartyDialogPrimitives.tsx
@@ -30,13 +30,27 @@ export function DialogCloseButton(props: { closeLabel: string; onClose: () => vo
       type="button"
       class={
         props.size === 'lg'
-          ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
+          ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-black/24 text-(--color-fg)'
           : 'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
       }
       aria-label={props.closeLabel}
       onClick={() => props.onClose()}
     >
-      ×
+      <svg
+        aria-hidden="true"
+        class={props.size === 'lg' ? 'h-7 w-7' : 'h-5 w-5'}
+        fill="none"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 6L18 18M18 6L6 18"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width={props.size === 'lg' ? '2.4' : '2'}
+        />
+      </svg>
     </button>
   )
 }

--- a/src/features/party-setup/TeamEditorDialog.tsx
+++ b/src/features/party-setup/TeamEditorDialog.tsx
@@ -18,15 +18,28 @@ type TeamEditorDialogProps = {
 }
 
 export function TeamEditorDialog(props: TeamEditorDialogProps) {
+  const selectedColors = () => teamColorClasses[props.draft.color]
+
   return (
     <DialogShell closeLabel={props.closeLabel} onClose={props.onClose} testId="team-editor-dialog">
       <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
-        <div class="flex items-start justify-between gap-3">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.24em] text-(--color-accent)">{props.title}</p>
-            <p class="mt-2 text-sm text-(--color-muted)">{props.subtitle}</p>
+        <div
+          class={clsx(
+            'rounded-[1.6rem] border p-4 transition-colors duration-150',
+            selectedColors().surface,
+            selectedColors().ring,
+          )}
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/18 px-2.5 py-1">
+                <span class={clsx('h-3.5 w-3.5 rounded-full ring-2 ring-white/30', selectedColors().chip)} />
+                <span class="text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">{props.title}</span>
+              </div>
+              <p class="mt-3 text-base font-semibold tracking-[-0.02em] text-(--color-fg)">{props.subtitle}</p>
+            </div>
+            <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} size="lg" />
           </div>
-          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} size="lg" />
         </div>
 
         <div class="mt-5 grid gap-5">
@@ -54,7 +67,7 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
                         'grid gap-2 rounded-2xl border p-3 text-left transition-transform',
                         teamColorClasses[color].chip,
                         props.draft.color === color
-                          ? 'border-white shadow-[0_0_0_1px_rgba(255,255,255,0.12)]'
+                          ? 'scale-[1.02] border-white shadow-[0_0_0_1px_rgba(255,255,255,0.12),0_16px_32px_rgba(255,255,255,0.08)]'
                           : 'border-transparent',
                         isDisabled() ? 'cursor-not-allowed opacity-30' : 'motion-safe:hover:-translate-y-0.5',
                       )}

--- a/src/features/party-setup/TeamSetupCard.tsx
+++ b/src/features/party-setup/TeamSetupCard.tsx
@@ -27,32 +27,53 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
     >
       <div
         class={clsx(
-          'grid gap-3 rounded-[1.15rem] bg-linear-to-br p-1.5',
+          'grid gap-3 rounded-[1.15rem] border-l-[6px] bg-linear-to-br p-3',
           teamColorClasses[props.selectedColor].surface,
+          {
+            'border-l-amber-300': props.selectedColor === 'amber',
+            'border-l-sky-300': props.selectedColor === 'sky',
+            'border-l-emerald-300': props.selectedColor === 'emerald',
+            'border-l-rose-300': props.selectedColor === 'rose',
+            'border-l-violet-300': props.selectedColor === 'violet',
+            'border-l-teal-300': props.selectedColor === 'teal',
+            'border-l-orange-300': props.selectedColor === 'orange',
+          },
         )}
       >
-        <div>
-          <p class="text-sm font-medium text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
-            {props.label}
-          </p>
-          <p class="mt-1 text-[11px] text-(--color-muted)">{props.subtitle}</p>
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class="truncate text-base font-semibold tracking-[-0.02em] text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
+              {props.label}
+            </p>
+            <p class="mt-1 truncate text-[11px] leading-5 text-(--color-muted)">{props.subtitle}</p>
+          </div>
+          <span class="shrink-0 rounded-full border border-white/10 bg-black/18 px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">
+            {props.editLabel}
+          </span>
         </div>
-        <div class="flex items-center justify-between gap-3">
-          <div class="grid grid-cols-4 gap-1.5">
+
+        <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/8 bg-black/12 px-3 py-2">
+          <div class="flex min-w-0 items-center gap-2">
+            <span class={clsx('h-3.5 w-3.5 shrink-0 rounded-full ring-2 ring-white/30', teamColorClasses[props.selectedColor].chip)} />
+            <span class="truncate text-[11px] font-medium uppercase tracking-[0.16em] text-(--color-muted)">
+              Active color
+            </span>
+          </div>
+
+          <div class="flex shrink-0 items-center gap-2">
             <For each={teamColorOptions}>
               {(color) => (
                 <span
                   class={clsx(
-                    'h-3 w-3 rounded-full border border-white/10',
+                    'h-3.5 w-3.5 rounded-full border border-white/10 ring-1 ring-transparent',
                     teamColorClasses[color].chip,
-                    props.selectedColor === color && 'scale-110 border-white/50',
+                    props.selectedColor === color && 'scale-110 border-white/50 ring-white/50',
                     props.selectedColor !== color && props.oppositeColor === color && 'opacity-25',
                   )}
                 />
               )}
             </For>
           </div>
-          <span class="text-[11px] uppercase tracking-[0.18em] text-(--color-muted)">{props.editLabel}</span>
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Summary
- write and store the team card redesign requirements, including the Gemini feedback that guided the changes
- rebuild the TeamSetupCard into a stronger identity plus palette layout that uses its space more efficiently
- strengthen the TeamEditorDialog feedback with color-reactive chrome and a visibly larger close icon

## Testing
- pnpm lint
- pnpm test
- pnpm build

Closes #91