### PR TITLE
fix: tighten team card mobile layout

### DIFF
--- a/src/features/party-setup/TeamSetupCard.tsx
+++ b/src/features/party-setup/TeamSetupCard.tsx
@@ -18,7 +18,7 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
     <button
       type="button"
       class={clsx(
-        'rounded-3xl border bg-black/10 p-3 text-left transition-transform motion-safe:hover:-translate-y-0.5',
+        'w-full rounded-3xl bg-transparent text-left transition-transform motion-safe:hover:-translate-y-0.5',
         teamColorClasses[props.selectedColor].ring,
         teamColorClasses[props.selectedColor].glow,
       )}
@@ -27,7 +27,7 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
     >
       <div
         class={clsx(
-          'grid gap-3 rounded-[1.15rem] border-l-[6px] bg-linear-to-br p-3',
+          'grid gap-2.5 rounded-[1.15rem] border-l-[6px] bg-linear-to-br px-3 py-2.5',
           teamColorClasses[props.selectedColor].surface,
           {
             'border-l-amber-300': props.selectedColor === 'amber',
@@ -40,19 +40,19 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
           },
         )}
       >
-        <div class="flex items-start justify-between gap-3">
+        <div class="flex items-start justify-between gap-2">
           <div class="min-w-0">
             <p class="truncate text-base font-semibold tracking-[-0.02em] text-(--color-fg)" data-testid={`team-label-${props.teamId}`}>
               {props.label}
             </p>
             <p class="mt-1 truncate text-[11px] leading-5 text-(--color-muted)">{props.subtitle}</p>
           </div>
-          <span class="shrink-0 rounded-full border border-white/10 bg-black/18 px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">
+          <span class="shrink-0 rounded-full bg-black/18 px-2 py-1 text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">
             {props.editLabel}
           </span>
         </div>
 
-        <div class="flex items-center justify-between gap-3 rounded-2xl border border-white/8 bg-black/12 px-3 py-2">
+        <div class="grid gap-2 rounded-2xl bg-black/12 px-2.5 py-2">
           <div class="flex min-w-0 items-center gap-2">
             <span class={clsx('h-3.5 w-3.5 shrink-0 rounded-full ring-2 ring-white/30', teamColorClasses[props.selectedColor].chip)} />
             <span class="truncate text-[11px] font-medium uppercase tracking-[0.16em] text-(--color-muted)">
@@ -60,7 +60,7 @@ export function TeamSetupCard(props: TeamSetupCardProps) {
             </span>
           </div>
 
-          <div class="flex shrink-0 items-center gap-2">
+          <div class="flex min-w-0 flex-wrap items-center gap-1.5">
             <For each={teamColorOptions}>
               {(color) => (
                 <span


### PR DESCRIPTION
## Summary
- remove extra team card outer border and padding
- allow the color swatch row to wrap on narrow widths
- tighten internal spacing to prevent horizontal overflow on iPhone 12 width

## Checks
- pnpm lint
- pnpm test src/features/party-setup/PartySetup.test.tsx
- pnpm build

Closes #93
