### PR TITLE
feat: use path-based app routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,32 @@
     />
     <meta property="og:type" content="website" />
     <title>TichuBoard</title>
+    <script>
+      ;(() => {
+        const current = new URL(window.location.href)
+        const routePath = current.searchParams.get('p')
+
+        if (!routePath) {
+          return
+        }
+
+        const basePath = '%BASE_URL%'
+        const nextPath = routePath.replace(/^\/+/, '')
+        const nextUrl = new URL(`${basePath}${nextPath}`, current.origin)
+        const redirectedSearch = current.searchParams.get('q')
+        const redirectedHash = current.searchParams.get('h')
+
+        if (redirectedSearch) {
+          nextUrl.search = `?${redirectedSearch}`
+        }
+
+        if (redirectedHash) {
+          nextUrl.hash = redirectedHash
+        }
+
+        window.history.replaceState(null, '', nextUrl.toString())
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>TichuBoard</title>
+    <script>
+      const basePath = '/tichu-board-r1/'
+      const current = window.location
+      const routePath = current.pathname.startsWith(basePath)
+        ? current.pathname.slice(basePath.length - 1)
+        : current.pathname
+      const redirect = new URL(basePath, current.origin)
+      redirect.searchParams.set('p', routePath)
+
+      if (current.search.length > 1) {
+        redirect.searchParams.set('q', current.search.slice(1))
+      }
+
+      if (current.hash.length > 1) {
+        redirect.searchParams.set('h', current.hash.slice(1))
+      }
+
+      window.location.replace(redirect.toString())
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import App from '@/App'
+import { getPathForRoute } from '@/shared/routes'
 import { seedStartedGameState } from '@/test/game-state'
 
 describe('App', () => {
   beforeEach(() => {
     localStorage.clear()
-    window.location.hash = ''
+    window.history.replaceState(null, '', '/')
   })
 
   it('shows the landing screen before a game starts', () => {
@@ -13,7 +14,7 @@ describe('App', () => {
 
     expect(screen.getByRole('heading', { name: /tichuboard/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /start scoring/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/start')
+    expect(window.location.pathname).toBe(getPathForRoute('start'))
     expect(screen.getByTestId('landing-layout')).toBeInTheDocument()
     expect(screen.getByTestId('landing-content').className).toContain('overflow-y-auto')
     expect(screen.getByTestId('app-shell').className).toContain('overflow-hidden')
@@ -25,18 +26,18 @@ describe('App', () => {
     await fireEvent.click(screen.getByRole('button', { name: /start scoring/i }))
 
     expect(screen.getByRole('heading', { name: /party setup/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/party')
+    expect(window.location.pathname).toBe(getPathForRoute('party'))
     expect(screen.getByRole('button', { name: /open settings/i })).toBeInTheDocument()
   })
 
-  it('switches pages through the tab bar and keeps route state in the hash', async () => {
+  it('switches pages through the tab bar and keeps route state in the pathname', async () => {
     seedStartedGameState('party')
     render(() => <App />)
 
     await fireEvent.click(screen.getByRole('button', { name: /^results$/i }))
 
     expect(screen.getByRole('heading', { name: /game results/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/results')
+    expect(window.location.pathname).toBe(getPathForRoute('results'))
   })
 
   it('moves to the next page with a left swipe gesture', async () => {
@@ -53,7 +54,7 @@ describe('App', () => {
     })
 
     expect(screen.getByRole('heading', { name: /round entry/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/round')
+    expect(window.location.pathname).toBe(getPathForRoute('round'))
   })
 
   it('can revisit the landing screen and continue the current game', async () => {
@@ -64,12 +65,12 @@ describe('App', () => {
     await fireEvent.click(screen.getByRole('button', { name: /show start screen/i }))
 
     expect(screen.getByRole('button', { name: /continue game/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/start')
+    expect(window.location.pathname).toBe(getPathForRoute('start'))
 
     await fireEvent.click(screen.getByRole('button', { name: /continue game/i }))
 
     expect(screen.getByRole('heading', { name: /party setup/i })).toBeInTheDocument()
-    expect(window.location.hash).toBe('#/party')
+    expect(window.location.pathname).toBe(getPathForRoute('party'))
   })
 
   it('shows the floating score summary after the first round is saved', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { SettingsDialog } from '@/features/settings/SettingsDialog'
 import { GameProvider, useGame } from '@/state/game-context'
 import {
   getDefaultRoute,
-  getHashForRoute,
+  getPathForRoute,
   type InGameRoute,
 } from '@/shared/routes'
 
@@ -27,11 +27,11 @@ function AppContent() {
 
   onMount(() => {
     syncRouteFromLocation()
-    window.addEventListener('hashchange', syncRouteFromLocation)
+    window.addEventListener('popstate', syncRouteFromLocation)
   })
 
   onCleanup(() => {
-    window.removeEventListener('hashchange', syncRouteFromLocation)
+    window.removeEventListener('popstate', syncRouteFromLocation)
   })
 
   createEffect(() => {
@@ -45,9 +45,9 @@ function AppContent() {
       return
     }
 
-    const expectedHash = getHashForRoute(route())
+    const expectedPath = getPathForRoute(route())
 
-    if (window.location.hash !== expectedHash) {
+    if (window.location.pathname !== expectedPath) {
       navigate(route(), { replace: true })
     }
   })

--- a/src/features/app/use-app-navigation.ts
+++ b/src/features/app/use-app-navigation.ts
@@ -2,8 +2,8 @@ import { createSignal } from 'solid-js'
 import type { PersistedGameState } from '@/domain/types'
 import {
   getDefaultRoute,
-  getHashForRoute,
-  getRouteFromHash,
+  getPathForRoute,
+  getRouteFromPath,
   type AppRoute,
 } from '@/shared/routes'
 
@@ -11,17 +11,17 @@ export function useAppNavigation(hasStartedGame: () => PersistedGameState['hasSt
   const [route, setRoute] = createSignal<AppRoute>(resolveInitialRoute(hasStartedGame()))
 
   const syncRouteFromLocation = () => {
-    setRoute(getRouteFromHash(window.location.hash, hasStartedGame()))
+    setRoute(getRouteFromPath(window.location.pathname, hasStartedGame()))
   }
 
   const navigate = (nextRoute: AppRoute, options?: { replace?: boolean }) => {
-    const nextHash = getHashForRoute(nextRoute)
+    const nextPath = getPathForRoute(nextRoute)
 
-    if (window.location.hash !== nextHash) {
+    if (window.location.pathname !== nextPath) {
       if (options?.replace) {
-        window.history.replaceState(null, '', nextHash)
+        window.history.replaceState(null, '', nextPath)
       } else {
-        window.history.pushState(null, '', nextHash)
+        window.history.pushState(null, '', nextPath)
       }
     }
 
@@ -40,5 +40,5 @@ function resolveInitialRoute(hasStartedGame: boolean): AppRoute {
     return getDefaultRoute(hasStartedGame)
   }
 
-  return getRouteFromHash(window.location.hash, hasStartedGame)
+  return getRouteFromPath(window.location.pathname, hasStartedGame)
 }

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -4,6 +4,8 @@ export const appRoutes = ['start', ...inGameRoutes] as const
 export type AppRoute = (typeof appRoutes)[number]
 export type InGameRoute = (typeof inGameRoutes)[number]
 
+const appBasePath = normalizeBasePath(import.meta.env.BASE_URL ?? '/')
+
 export function isAppRoute(value: string): value is AppRoute {
   return appRoutes.includes(value as AppRoute)
 }
@@ -16,8 +18,8 @@ export function getDefaultRoute(hasStartedGame: boolean): AppRoute {
   return hasStartedGame ? 'party' : 'start'
 }
 
-export function getRouteFromHash(hash: string, hasStartedGame: boolean): AppRoute {
-  const normalized = hash.replace(/^#\/?/, '')
+export function getRouteFromPath(pathname: string, hasStartedGame: boolean): AppRoute {
+  const normalized = trimBasePath(pathname)
 
   if (isAppRoute(normalized)) {
     return hasStartedGame || normalized === 'start' ? normalized : 'start'
@@ -26,8 +28,8 @@ export function getRouteFromHash(hash: string, hasStartedGame: boolean): AppRout
   return getDefaultRoute(hasStartedGame)
 }
 
-export function getHashForRoute(route: AppRoute) {
-  return `#/${route}`
+export function getPathForRoute(route: AppRoute) {
+  return `${appBasePath}${route}`
 }
 
 export function getAdjacentRoute(route: InGameRoute, direction: 'next' | 'previous'): InGameRoute {
@@ -38,4 +40,25 @@ export function getAdjacentRoute(route: InGameRoute, direction: 'next' | 'previo
       : Math.max(0, currentIndex - 1)
 
   return inGameRoutes[targetIndex]!
+}
+
+function normalizeBasePath(basePath: string) {
+  const trimmed = basePath.replace(/^\/+|\/+$/g, '')
+
+  return trimmed.length > 0 ? `/${trimmed}/` : '/'
+}
+
+function trimBasePath(pathname: string) {
+  const normalizedPathname = pathname.replace(/\/+$/, '') || '/'
+  const baseWithoutTrailingSlash = appBasePath.replace(/\/+$/, '') || '/'
+
+  if (normalizedPathname === baseWithoutTrailingSlash) {
+    return ''
+  }
+
+  if (normalizedPathname.startsWith(appBasePath)) {
+    return normalizedPathname.slice(appBasePath.length).replace(/^\/+|\/+$/g, '')
+  }
+
+  return normalizedPathname.replace(/^\/+|\/+$/g, '')
 }

--- a/src/test/game-state.ts
+++ b/src/test/game-state.ts
@@ -1,5 +1,5 @@
 import { createDefaultPlayers, createDefaultSettings } from '@/domain/defaults'
-import { getHashForRoute, type AppRoute } from '@/shared/routes'
+import { getPathForRoute, type AppRoute } from '@/shared/routes'
 import { STORAGE_KEY } from '@/storage/game-storage'
 
 export function seedStartedGameState(route: AppRoute = 'party') {
@@ -16,5 +16,5 @@ export function seedStartedGameState(route: AppRoute = 'party') {
     }),
   )
 
-  window.location.hash = getHashForRoute(route)
+  window.history.replaceState(null, '', getPathForRoute(route))
 }


### PR DESCRIPTION
## Summary
- replace hash navigation with pathname-based routes
- preserve direct URL entry and refresh by parsing real app paths
- add a GitHub Pages 404 fallback that rewrites SPA routes back into the app

## Checks
- pnpm lint
- pnpm test src/App.test.tsx
- pnpm test
- pnpm build

Closes #95
