### PR TITLE
refactor: formalize site route definitions

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,6 +30,16 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: /open settings/i })).toBeInTheDocument()
   })
 
+  it('renders the correct page when opened from a direct site route', () => {
+    seedStartedGameState('results')
+    window.history.replaceState(null, '', getPathForRoute('results'))
+
+    render(() => <App />)
+
+    expect(screen.getByRole('heading', { name: /game results/i })).toBeInTheDocument()
+    expect(window.location.pathname).toBe(getPathForRoute('results'))
+  })
+
   it('switches pages through the tab bar and keeps route state in the pathname', async () => {
     seedStartedGameState('party')
     render(() => <App />)

--- a/src/shared/routes.test.ts
+++ b/src/shared/routes.test.ts
@@ -1,0 +1,40 @@
+import {
+  getAppBasePath,
+  getDefaultRoute,
+  getPathForRoute,
+  getRouteFromPath,
+  getRouteSegment,
+} from '@/shared/routes'
+
+describe('routes', () => {
+  it('builds real site paths for each app route', () => {
+    expect(getPathForRoute('start')).toBe(`${getAppBasePath()}start`)
+    expect(getPathForRoute('party')).toBe(`${getAppBasePath()}party`)
+    expect(getPathForRoute('round')).toBe(`${getAppBasePath()}round`)
+    expect(getPathForRoute('results')).toBe(`${getAppBasePath()}results`)
+    expect(getPathForRoute('history')).toBe(`${getAppBasePath()}history`)
+  })
+
+  it('maps the app base path to the default route', () => {
+    expect(getRouteFromPath(getAppBasePath(), false)).toBe(getDefaultRoute(false))
+    expect(getRouteFromPath(getAppBasePath(), true)).toBe(getDefaultRoute(true))
+  })
+
+  it('keeps in-game paths only when a game has started', () => {
+    expect(getRouteFromPath(getPathForRoute('round'), true)).toBe('round')
+    expect(getRouteFromPath(getPathForRoute('round'), false)).toBe('start')
+  })
+
+  it('falls back to the default route for unknown paths', () => {
+    expect(getRouteFromPath(`${getAppBasePath()}unknown`, false)).toBe('start')
+    expect(getRouteFromPath(`${getAppBasePath()}unknown`, true)).toBe('party')
+  })
+
+  it('exposes stable route segments for URL structure', () => {
+    expect(getRouteSegment('start')).toBe('start')
+    expect(getRouteSegment('party')).toBe('party')
+    expect(getRouteSegment('round')).toBe('round')
+    expect(getRouteSegment('results')).toBe('results')
+    expect(getRouteSegment('history')).toBe('history')
+  })
+})

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -6,6 +6,29 @@ export type InGameRoute = (typeof inGameRoutes)[number]
 
 const appBasePath = normalizeBasePath(import.meta.env.BASE_URL ?? '/')
 
+export const routeDefinitions = {
+  start: {
+    segment: 'start',
+    path: buildRoutePath('start'),
+  },
+  party: {
+    segment: 'party',
+    path: buildRoutePath('party'),
+  },
+  round: {
+    segment: 'round',
+    path: buildRoutePath('round'),
+  },
+  results: {
+    segment: 'results',
+    path: buildRoutePath('results'),
+  },
+  history: {
+    segment: 'history',
+    path: buildRoutePath('history'),
+  },
+} as const
+
 export function isAppRoute(value: string): value is AppRoute {
   return appRoutes.includes(value as AppRoute)
 }
@@ -29,7 +52,15 @@ export function getRouteFromPath(pathname: string, hasStartedGame: boolean): App
 }
 
 export function getPathForRoute(route: AppRoute) {
-  return `${appBasePath}${route}`
+  return routeDefinitions[route].path
+}
+
+export function getRouteSegment(route: AppRoute) {
+  return routeDefinitions[route].segment
+}
+
+export function getAppBasePath() {
+  return appBasePath
 }
 
 export function getAdjacentRoute(route: InGameRoute, direction: 'next' | 'previous'): InGameRoute {
@@ -46,6 +77,10 @@ function normalizeBasePath(basePath: string) {
   const trimmed = basePath.replace(/^\/+|\/+$/g, '')
 
   return trimmed.length > 0 ? `/${trimmed}/` : '/'
+}
+
+function buildRoutePath(route: AppRoute) {
+  return `${appBasePath}${route}`
 }
 
 function trimBasePath(pathname: string) {


### PR DESCRIPTION
## Summary
- centralize real site URL route definitions and path helpers
- add direct-path route tests for refresh and URL entry scenarios
- make the path-based route structure explicit and stable

## Checks
- pnpm lint
- pnpm test src/shared/routes.test.ts src/App.test.tsx
- pnpm test
- pnpm build

Closes #97
