### PR TITLE
fix: polish team editor dialog feedback

### DIFF
--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -38,16 +38,20 @@ describe('PartySetup', () => {
     render(() => <App />)
 
     await fireEvent.click(screen.getByTestId('team-name-north-south'))
+    expect(screen.getByText(/adjust team 1 name and color/i)).toBeInTheDocument()
     await fireEvent.input(screen.getByTestId('team-editor-name-north-south'), {
       target: { value: 'Alpha Team' },
     })
     await waitFor(() => {
       expect(screen.getByTestId('team-label-north-south')).toHaveTextContent('Alpha Team')
     })
+    expect(screen.getByText(/adjust alpha team name and color/i)).toBeInTheDocument()
     await fireEvent.click(screen.getByTestId('team-editor-color-violet'))
     await waitFor(() => {
       expect(screen.getByTestId('team-name-north-south').className).toContain('ring-violet-300/55')
     })
+    expect(screen.getByTestId('team-editor-color-violet').className).toContain('ring-2')
+    expect(screen.getByTestId('team-editor-dialog').firstElementChild?.className).toContain('from-violet-300/18')
 
     expect(screen.getByTestId('team-label-north-south')).toHaveTextContent('Alpha Team')
     expect(screen.getByTestId('team-name-north-south')).toHaveTextContent('Alpha Team')

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -105,7 +105,7 @@ export function PartySetup() {
           oppositeTeamColor={controller.state.settings.teamColors[controller.activeTeamId(controller.teamEditorDraft()!.teamId)]}
           title={controller.t('party.teamEditorTitle')}
           subtitle={controller.t('party.teamEditorSubtitle', {
-            team: controller.teamEditorDraft()!.teamId === 'north-south' ? '1' : '2',
+            team: controller.teamEditorDraft()!.name.trim() || (controller.teamEditorDraft()!.teamId === 'north-south' ? 'Team 1' : 'Team 2'),
           })}
           closeLabel={controller.t('party.closeTeamEditor')}
           nameFieldLabel={controller.t('party.teamNameField')}

--- a/src/features/party-setup/TeamEditorDialog.tsx
+++ b/src/features/party-setup/TeamEditorDialog.tsx
@@ -22,24 +22,17 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
 
   return (
     <DialogShell closeLabel={props.closeLabel} onClose={props.onClose} testId="team-editor-dialog">
-      <div class="flex-1 overflow-y-auto px-5 pb-6 pt-6 sm:p-5">
-        <div
-          class={clsx(
-            'rounded-[1.6rem] border p-4 transition-colors duration-150',
-            selectedColors().surface,
-            selectedColors().ring,
-          )}
-        >
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/18 px-2.5 py-1">
-                <span class={clsx('h-3.5 w-3.5 rounded-full ring-2 ring-white/30', selectedColors().chip)} />
-                <span class="text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">{props.title}</span>
-              </div>
-              <p class="mt-3 text-base font-semibold tracking-[-0.02em] text-(--color-fg)">{props.subtitle}</p>
+      <div class={clsx('flex-1 overflow-y-auto px-5 pb-6 pt-6 transition-colors duration-200 sm:p-5', selectedColors().surface)}>
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="inline-flex items-center gap-2 rounded-full bg-black/18 px-2.5 py-1">
+              <span class={clsx('h-3.5 w-3.5 rounded-full ring-2 ring-white/30', selectedColors().chip)} />
+              <span class="text-[10px] uppercase tracking-[0.18em] text-(--color-muted)">{props.title}</span>
             </div>
-            <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} size="lg" />
+            <p class="mt-3 text-base font-semibold tracking-[-0.02em] text-(--color-fg)">{props.subtitle}</p>
+            <p class="mt-1 truncate text-xs leading-5 text-(--color-muted)">{props.draft.name.trim() || props.subtitle}</p>
           </div>
+          <DialogCloseButton closeLabel={props.closeLabel} onClose={props.onClose} size="lg" />
         </div>
 
         <div class="mt-5 grid gap-5">
@@ -64,11 +57,11 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
                     <button
                       type="button"
                       class={clsx(
-                        'grid gap-2 rounded-2xl border p-3 text-left transition-transform',
-                        teamColorClasses[color].chip,
+                        'grid gap-2 rounded-2xl border p-3 text-left transition-all duration-150',
+                        teamColorClasses[color].surface,
                         props.draft.color === color
-                          ? 'scale-[1.02] border-white shadow-[0_0_0_1px_rgba(255,255,255,0.12),0_16px_32px_rgba(255,255,255,0.08)]'
-                          : 'border-transparent',
+                          ? 'scale-[1.02] border-white/70 ring-2 ring-white/45 shadow-[0_0_0_1px_rgba(255,255,255,0.16),0_18px_36px_rgba(15,23,42,0.24)]'
+                          : 'border-white/8',
                         isDisabled() ? 'cursor-not-allowed opacity-30' : 'motion-safe:hover:-translate-y-0.5',
                       )}
                       aria-disabled={isDisabled()}
@@ -77,7 +70,7 @@ export function TeamEditorDialog(props: TeamEditorDialogProps) {
                       data-testid={`team-editor-color-${color}`}
                       onClick={() => props.onColorSelect(color)}
                     >
-                      <span class="h-3 w-8 rounded-full bg-black/20" />
+                      <span class={clsx('h-3 w-8 rounded-full ring-1 ring-black/10', teamColorClasses[color].chip)} />
                       <span class="text-[11px] font-semibold uppercase tracking-[0.18em]">{color}</span>
                     </button>
                   )

--- a/src/shared/i18n/en.ts
+++ b/src/shared/i18n/en.ts
@@ -87,7 +87,7 @@ export const enDictionary = flatten({
     moveSeat: 'Move on table',
     editTeam: 'Edit team',
     teamEditorTitle: 'Edit team',
-    teamEditorSubtitle: 'Adjust Team {{ team }} name and color',
+    teamEditorSubtitle: 'Adjust {{ team }} name and color',
     closeTeamEditor: 'Close team editor',
     pendingSeatMove: 'Move {{ name }} to another seat',
     pendingRecentName: 'Apply {{ name }} to a seat',

--- a/src/shared/i18n/ko.ts
+++ b/src/shared/i18n/ko.ts
@@ -85,7 +85,7 @@ export const koDictionary = flatten({
     moveSeat: '테이블에서 이동',
     editTeam: '팀 수정',
     teamEditorTitle: '팀 설정 수정',
-    teamEditorSubtitle: '{{ team }}팀 이름과 색상을 조정합니다.',
+    teamEditorSubtitle: '{{ team }} 이름과 색상을 조정합니다.',
     closeTeamEditor: '팀 편집 닫기',
     pendingSeatMove: '{{ name }} 플레이어 자리를 선택하세요',
     pendingRecentName: '{{ name }} 이름을 적용할 좌석을 선택하세요',


### PR DESCRIPTION
## Summary
- remove the extra bordered header box from the team editor dialog
- keep the team editor description synced with the current edited team name
- strengthen color selection feedback through dialog surface tint and stronger selected swatch emphasis

## Checks
- pnpm lint
- pnpm test src/features/party-setup/PartySetup.test.tsx
- pnpm test
- pnpm build

Closes #99
