### PR TITLE
fix: keep explicit routes on direct entry

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,6 +20,15 @@ describe('App', () => {
     expect(screen.getByTestId('app-shell').className).toContain('overflow-hidden')
   })
 
+  it('keeps an explicit party route on direct entry even without a started game', () => {
+    window.history.replaceState(null, '', getPathForRoute('party'))
+
+    render(() => <App />)
+
+    expect(screen.getByRole('heading', { name: /party setup/i })).toBeInTheDocument()
+    expect(window.location.pathname).toBe(getPathForRoute('party'))
+  })
+
   it('enters the scoring screen after pressing start', async () => {
     render(() => <App />)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,12 +35,6 @@ function AppContent() {
   })
 
   createEffect(() => {
-    if (!state.hasStartedGame && route() !== 'start') {
-      navigate('start', { replace: true })
-    }
-  })
-
-  createEffect(() => {
     if (typeof window === 'undefined') {
       return
     }

--- a/src/shared/routes.test.ts
+++ b/src/shared/routes.test.ts
@@ -20,9 +20,10 @@ describe('routes', () => {
     expect(getRouteFromPath(getAppBasePath(), true)).toBe(getDefaultRoute(true))
   })
 
-  it('keeps in-game paths only when a game has started', () => {
+  it('keeps explicit in-game paths even when no game has started', () => {
     expect(getRouteFromPath(getPathForRoute('round'), true)).toBe('round')
-    expect(getRouteFromPath(getPathForRoute('round'), false)).toBe('start')
+    expect(getRouteFromPath(getPathForRoute('round'), false)).toBe('round')
+    expect(getRouteFromPath(getPathForRoute('party'), false)).toBe('party')
   })
 
   it('falls back to the default route for unknown paths', () => {

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -44,8 +44,12 @@ export function getDefaultRoute(hasStartedGame: boolean): AppRoute {
 export function getRouteFromPath(pathname: string, hasStartedGame: boolean): AppRoute {
   const normalized = trimBasePath(pathname)
 
+  if (normalized.length === 0) {
+    return getDefaultRoute(hasStartedGame)
+  }
+
   if (isAppRoute(normalized)) {
-    return hasStartedGame || normalized === 'start' ? normalized : 'start'
+    return normalized
   }
 
   return getDefaultRoute(hasStartedGame)


### PR DESCRIPTION
## Summary
- keep explicit page paths like /party on direct entry even without an in-progress game
- route only the root path / to /start when there is no active game
- remove the extra start-route guard that overrode explicit site URLs

## Checks
- pnpm test src/shared/routes.test.ts src/App.test.tsx
- pnpm lint
- pnpm test
- pnpm build

Closes #103
