### PR TITLE
feat: add touch drag bench interactions

### DIFF
--- a/src/features/party-setup/PartyBench.tsx
+++ b/src/features/party-setup/PartyBench.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
-import { For, Show } from 'solid-js'
-import type { PlayerId, TeamColor } from '@/domain/types'
+import { For, Show, createSignal, onCleanup } from 'solid-js'
+import type { PlayerId, Seat, TeamColor } from '@/domain/types'
 import { teamColorClasses } from './party-setup.shared'
 
 type BenchPlayer = {
@@ -18,6 +18,7 @@ type PartyBenchProps = {
   onArmPlayer: (playerId: PlayerId) => void
   onDragPlayerStart: (playerId: PlayerId) => void
   onDragPlayerEnd: () => void
+  onDragPlayerDrop: (seat: Seat) => void
   onRecentNameClick: (name: string) => void
   onRecentNameDragStart: (name: string) => void
   onRecentNameDragEnd: () => void
@@ -28,6 +29,137 @@ type PartyBenchProps = {
 }
 
 export function PartyBench(props: PartyBenchProps) {
+  const [suppressClickPlayerId, setSuppressClickPlayerId] = createSignal<PlayerId | null>(null)
+  const [dragPreview, setDragPreview] = createSignal<{
+    playerId: PlayerId
+    name: string
+    seatInitial: string
+    teamColor: TeamColor
+    x: number
+    y: number
+    hasStarted: boolean
+  } | null>(null)
+
+  let activePointerId: number | null = null
+  let originX = 0
+  let originY = 0
+
+  const clearPointerDrag = () => {
+    activePointerId = null
+    originX = 0
+    originY = 0
+    setDragPreview(null)
+    window.removeEventListener('pointermove', handlePointerMove)
+    window.removeEventListener('pointerup', handlePointerUp)
+    window.removeEventListener('pointercancel', handlePointerCancel)
+  }
+
+  const resolveSeatAtPoint = (x: number, y: number): Seat | null => {
+    const target = document.elementFromPoint(x, y)
+
+    if (!(target instanceof HTMLElement)) {
+      return null
+    }
+
+    const seatTarget = target.closest<HTMLElement>('[data-seat-id]')
+    const seat = seatTarget?.dataset.seatId
+
+    return seat === 'north' || seat === 'east' || seat === 'south' || seat === 'west' ? seat : null
+  }
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (event.pointerId !== activePointerId) {
+      return
+    }
+
+    setDragPreview((current) => {
+      if (!current) {
+        return current
+      }
+
+      const distance = Math.hypot(event.clientX - originX, event.clientY - originY)
+      const hasStarted = current.hasStarted || distance > 8
+
+      if (hasStarted && !current.hasStarted) {
+        props.onDragPlayerStart(current.playerId)
+      }
+
+      return {
+        ...current,
+        x: event.clientX,
+        y: event.clientY,
+        hasStarted,
+      }
+    })
+  }
+
+  const handlePointerUp = (event: PointerEvent) => {
+    if (event.pointerId !== activePointerId) {
+      return
+    }
+
+    const current = dragPreview()
+
+    if (!current) {
+      clearPointerDrag()
+      return
+    }
+
+    if (!current.hasStarted) {
+      props.onArmPlayer(current.playerId)
+      setSuppressClickPlayerId(current.playerId)
+      clearPointerDrag()
+      return
+    }
+
+    const seat = resolveSeatAtPoint(event.clientX, event.clientY)
+
+    if (seat) {
+      props.onDragPlayerDrop(seat)
+    } else {
+      props.onDragPlayerEnd()
+    }
+
+    setSuppressClickPlayerId(current.playerId)
+    clearPointerDrag()
+  }
+
+  const handlePointerCancel = (event: PointerEvent) => {
+    if (event.pointerId !== activePointerId) {
+      return
+    }
+
+    if (dragPreview()?.hasStarted) {
+      props.onDragPlayerEnd()
+    }
+
+    clearPointerDrag()
+  }
+
+  const startPointerDrag = (event: PointerEvent, player: BenchPlayer) => {
+    if (event.button !== 0) {
+      return
+    }
+
+    activePointerId = event.pointerId
+    originX = event.clientX
+    originY = event.clientY
+    setDragPreview({
+      playerId: player.id,
+      name: player.name,
+      seatInitial: player.seatInitial,
+      teamColor: player.teamColor,
+      x: event.clientX,
+      y: event.clientY,
+      hasStarted: false,
+    })
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerCancel)
+  }
+
+  onCleanup(() => clearPointerDrag())
+
   return (
     <section class="grid gap-3 rounded-4xl border border-white/10 bg-black/12 p-3">
       <div class="flex items-center justify-between gap-3">
@@ -53,16 +185,21 @@ export function PartyBench(props: PartyBenchProps) {
               <button
                 type="button"
                 class={clsx(
-                  'inline-flex min-h-12 items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-transform',
+                  'inline-flex min-h-12 touch-none items-center gap-2 rounded-full border px-3 py-2 text-left text-sm transition-transform',
                   props.armedPlayerId === player.id
                     ? 'border-(--color-accent) bg-(--color-accent) text-slate-950'
                     : 'border-white/10 bg-(--color-surface) text-(--color-fg) motion-safe:hover:-translate-y-0.5',
                 )}
-                draggable="true"
                 data-testid={`bench-player-${player.id}`}
-                onClick={() => props.onArmPlayer(player.id)}
-                onDragStart={() => props.onDragPlayerStart(player.id)}
-                onDragEnd={props.onDragPlayerEnd}
+                onClick={() => {
+                  if (suppressClickPlayerId() === player.id) {
+                    setSuppressClickPlayerId(null)
+                    return
+                  }
+
+                  props.onArmPlayer(player.id)
+                }}
+                onPointerDown={(event) => startPointerDrag(event, player)}
               >
                 <span
                   class={clsx(
@@ -103,6 +240,29 @@ export function PartyBench(props: PartyBenchProps) {
           </div>
         </Show>
       </div>
+
+      <Show when={dragPreview() && dragPreview()!.hasStarted}>
+        <div
+          class="pointer-events-none fixed left-0 top-0 z-60 -translate-x-1/2 -translate-y-1/2"
+          style={{
+            left: `${dragPreview()!.x}px`,
+            top: `${dragPreview()!.y}px`,
+          }}
+          data-testid="bench-drag-preview"
+        >
+          <div class="inline-flex min-h-12 items-center gap-2 rounded-full border border-white/14 bg-[color-mix(in_srgb,var(--color-surface)_94%,#020617)] px-3 py-2 text-sm text-(--color-fg) shadow-[0_18px_40px_rgba(15,23,42,0.3)]">
+            <div
+              class={clsx(
+                'inline-flex h-8 w-8 items-center justify-center rounded-full text-[11px] font-semibold',
+                teamColorClasses[dragPreview()!.teamColor].chip,
+              )}
+            >
+              {dragPreview()!.seatInitial}
+            </div>
+            <span class="font-medium">{dragPreview()!.name}</span>
+          </div>
+        </div>
+      </Show>
     </section>
   )
 }

--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -28,10 +28,27 @@ describe('PartySetup', () => {
     expect(within(screen.getByTestId('seat-north')).getByText('Alice')).toBeInTheDocument()
 
     const playerBenchChip = screen.getByTestId('bench-player-player-1')
-    await fireEvent.dragStart(playerBenchChip)
-    await fireEvent.drop(screen.getByTestId('seat-east'))
+    const seatEast = screen.getByTestId('seat-east')
+    const originalElementFromPoint = document.elementFromPoint
+    const elementFromPoint = vi.fn(() => seatEast)
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: elementFromPoint,
+    })
+
+    await fireEvent.pointerDown(playerBenchChip, { button: 0, pointerId: 1, clientX: 20, clientY: 20 })
+    await fireEvent.pointerMove(window, { pointerId: 1, clientX: 80, clientY: 90 })
+
+    expect(screen.getByTestId('bench-drag-preview')).toHaveTextContent('Alice')
+
+    await fireEvent.pointerUp(window, { pointerId: 1, clientX: 120, clientY: 120 })
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: originalElementFromPoint,
+    })
 
     expect(within(screen.getByTestId('seat-east')).getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByTestId('bench-drag-preview')).not.toBeInTheDocument()
   })
 
   it('can rename teams, reroll a unique name, disable used team colors, and block duplicate names', async () => {

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -54,6 +54,7 @@ export function PartySetup() {
         onArmPlayer={controller.armPlayer}
         onDragPlayerStart={controller.startDraggingPlayer}
         onDragPlayerEnd={controller.stopDraggingPlayer}
+        onDragPlayerDrop={controller.handleSeatAssign}
         onRecentNameClick={controller.selectRecentName}
         onRecentNameDragStart={controller.startDraggingRecentName}
         onRecentNameDragEnd={controller.stopDraggingRecentName}

--- a/src/features/party-setup/SeatMapBoard.tsx
+++ b/src/features/party-setup/SeatMapBoard.tsx
@@ -77,7 +77,8 @@ export function SeatMapBoard(props: SeatMapBoardProps) {
               onDragOver={(event) => event.preventDefault()}
               onDrop={() => props.onSeatAssign(entry.seat)}
               data-testid={`seat-${entry.seat}`}
-              >
+              data-seat-id={entry.seat}
+            >
               <div class={clsx('pointer-events-none absolute inset-0 bg-linear-to-br opacity-70', colors.surface)} />
               <span
                 class="pointer-events-none absolute inset-0 flex items-center justify-center text-[clamp(3.5rem,20vw,5.25rem)] font-black tracking-[-0.08em] text-white/6"


### PR DESCRIPTION
## Summary
- add pointer-following drag interactions for party bench player chips
- allow dropping a dragged bench player onto seat map targets to reassign seats
- update party setup tests for touch drag preview and seat-drop highlighting

Closes #117

## Checks
- pnpm test src/features/party-setup/PartySetup.test.tsx
- pnpm lint
- pnpm test
- pnpm build