### PR TITLE
fix: persist settings and unify dialog close buttons

### DIFF
--- a/src/features/party-setup/PartyDialogPrimitives.tsx
+++ b/src/features/party-setup/PartyDialogPrimitives.tsx
@@ -1,5 +1,6 @@
 import type { ParentProps } from 'solid-js'
 import { Portal } from 'solid-js/web'
+export { DialogCloseButton } from '@/shared/DialogCloseButton'
 
 export function DialogShell(props: ParentProps<{ closeLabel: string; onClose: () => void; testId: string }>) {
   return (
@@ -21,37 +22,6 @@ export function DialogShell(props: ParentProps<{ closeLabel: string; onClose: ()
         </div>
       </div>
     </Portal>
-  )
-}
-
-export function DialogCloseButton(props: { closeLabel: string; onClose: () => void; size?: 'md' | 'lg' }) {
-  return (
-    <button
-      type="button"
-      class={
-        props.size === 'lg'
-          ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-black/24 text-(--color-fg)'
-          : 'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
-      }
-      aria-label={props.closeLabel}
-      onClick={() => props.onClose()}
-    >
-      <svg
-        aria-hidden="true"
-        class={props.size === 'lg' ? 'h-7 w-7' : 'h-5 w-5'}
-        fill="none"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M6 6L18 18M18 6L6 18"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width={props.size === 'lg' ? '2.4' : '2'}
-        />
-      </svg>
-    </button>
   )
 }
 

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { For, Show } from 'solid-js'
 import type { ThemeMode } from '@/domain/types'
+import { DialogCloseButton } from '@/shared/DialogCloseButton'
 import { useGame } from '@/state/game-context'
 
 const themeModes: ThemeMode[] = ['system', 'light', 'dark']
@@ -47,28 +48,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
               </p>
             </div>
 
-            <button
-              type="button"
-              class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/15 text-(--color-fg)"
-              aria-label={t('settings.close')}
-              onClick={() => props.onClose()}
-            >
-              <svg
-                aria-hidden="true"
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6 6L18 18M18 6L6 18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.8"
-                />
-              </svg>
-            </button>
+            <DialogCloseButton closeLabel={t('settings.close')} onClose={() => props.onClose()} />
           </div>
 
           <div class="mt-6 grid gap-5">

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import App from '@/App'
+import { SETTINGS_STORAGE_KEY } from '@/storage/game-storage'
 import { seedStartedGameState } from '@/test/game-state'
 
 describe('SettingsPanel', () => {
@@ -30,5 +31,28 @@ describe('SettingsPanel', () => {
     await fireEvent.click(screen.getByRole('button', { name: /light/i }))
 
     expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('persists language and theme across a remount', async () => {
+    const view = render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /open settings/i }))
+    await fireEvent.click(screen.getByRole('button', { name: /light/i }))
+    await fireEvent.click(screen.getByRole('button', { name: /korean/i }))
+
+    expect(document.documentElement.lang).toBe('ko')
+    expect(document.documentElement.dataset.theme).toBe('light')
+    await waitFor(() => {
+      expect(localStorage.getItem(SETTINGS_STORAGE_KEY)).toContain('"language":"ko"')
+      expect(localStorage.getItem(SETTINGS_STORAGE_KEY)).toContain('"theme":"light"')
+    })
+
+    view.unmount()
+    render(() => <App />)
+
+    expect(document.documentElement.lang).toBe('ko')
+    expect(document.documentElement.dataset.theme).toBe('light')
+    await fireEvent.click(screen.getByRole('button', { name: /설정 열기/i }))
+    expect(screen.getByText(/테이블 설정/i)).toBeInTheDocument()
   })
 })

--- a/src/shared/DialogCloseButton.tsx
+++ b/src/shared/DialogCloseButton.tsx
@@ -1,0 +1,30 @@
+export function DialogCloseButton(props: { closeLabel: string; onClose: () => void; size?: 'md' | 'lg' }) {
+  return (
+    <button
+      type="button"
+      class={
+        props.size === 'lg'
+          ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-black/24 text-(--color-fg)'
+          : 'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/20 text-(--color-fg)'
+      }
+      aria-label={props.closeLabel}
+      onClick={() => props.onClose()}
+    >
+      <svg
+        aria-hidden="true"
+        class={props.size === 'lg' ? 'h-7 w-7' : 'h-5 w-5'}
+        fill="none"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 6L18 18M18 6L6 18"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width={props.size === 'lg' ? '2.4' : '2'}
+        />
+      </svg>
+    </button>
+  )
+}

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -9,7 +9,7 @@ import {
 } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
 import { calculateCumulativeScores, getGameStatus, getLeadingTeamId } from '@/domain/scoring'
-import { saveGameState } from '@/storage/game-storage'
+import { saveGameState, saveSettings } from '@/storage/game-storage'
 import { createTranslator } from '@/shared/i18n'
 import { createGameActions } from './game-context-actions'
 import {
@@ -31,6 +31,18 @@ export const GameProvider: ParentComponent = (props) => {
   const leadingTeamId = createMemo(() => getLeadingTeamId(cumulativeScores()))
   const teamLineups = createMemo(() => createTeamLineups(state.players))
   const teamNames = createMemo(() => state.settings.teamNames)
+  const persistedSettings = createMemo(() => ({
+    language: state.settings.language,
+    theme: state.settings.theme,
+    teamColors: {
+      'north-south': state.settings.teamColors['north-south'],
+      'east-west': state.settings.teamColors['east-west'],
+    },
+    teamNames: {
+      'north-south': state.settings.teamNames['north-south'],
+      'east-west': state.settings.teamNames['east-west'],
+    },
+  }))
   const effectiveTheme = createMemo(() => (state.settings.theme === 'system' ? systemTheme() : state.settings.theme))
 
   const mediaQuery =
@@ -47,6 +59,10 @@ export const GameProvider: ParentComponent = (props) => {
 
   createEffect(() => {
     saveGameState(window.localStorage, unwrap(state))
+  })
+
+  createEffect(() => {
+    saveSettings(window.localStorage, persistedSettings())
   })
 
   createEffect(() => {

--- a/src/storage/game-storage.test.ts
+++ b/src/storage/game-storage.test.ts
@@ -5,7 +5,11 @@ import {
   createInitialGameState,
   deserializeGameState,
   loadGameState,
+  loadSettings,
+  normalizeSettings,
   saveGameState,
+  saveSettings,
+  SETTINGS_STORAGE_KEY,
   STORAGE_KEY,
 } from '@/storage/game-storage'
 
@@ -86,5 +90,65 @@ describe('game storage', () => {
     clearGameState(localStorage)
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('loads standalone persisted settings when game state is missing', () => {
+    saveSettings(localStorage, {
+      ...createDefaultSettings(),
+      language: 'ko',
+      theme: 'light',
+    })
+
+    expect(loadGameState(localStorage).settings).toEqual({
+      ...createDefaultSettings(),
+      language: 'ko',
+      theme: 'light',
+    })
+  })
+
+  it('keeps standalone persisted settings when the game state payload is invalid', () => {
+    localStorage.setItem(STORAGE_KEY, '{"schemaVersion":99}')
+    saveSettings(localStorage, {
+      ...createDefaultSettings(),
+      language: 'ko',
+      theme: 'dark',
+    })
+
+    expect(loadGameState(localStorage).settings).toEqual({
+      ...createDefaultSettings(),
+      language: 'ko',
+      theme: 'dark',
+    })
+  })
+
+  it('serializes and hydrates settings separately', () => {
+    const settings = {
+      ...createDefaultSettings(),
+      language: 'ko' as const,
+      theme: 'light' as const,
+    }
+
+    saveSettings(localStorage, settings)
+
+    expect(loadSettings(localStorage)).toEqual(settings)
+  })
+
+  it('falls back to defaults for malformed settings payloads', () => {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, '{not-json')
+
+    expect(loadSettings(localStorage)).toEqual(createDefaultSettings())
+  })
+
+  it('normalizes partial settings payloads', () => {
+    expect(
+      normalizeSettings({
+        language: 'ko',
+        theme: 'dark',
+      }),
+    ).toEqual({
+      ...createDefaultSettings(),
+      language: 'ko',
+      theme: 'dark',
+    })
   })
 })

--- a/src/storage/game-storage.ts
+++ b/src/storage/game-storage.ts
@@ -1,7 +1,8 @@
 import { createDefaultPlayers, createDefaultSettings } from '@/domain/defaults'
-import type { PersistedGameState } from '@/domain/types'
+import type { GameSettings, PersistedGameState } from '@/domain/types'
 
 export const STORAGE_KEY = 'tichu-board-r1:v1'
+export const SETTINGS_STORAGE_KEY = 'tichu-board-r1:settings:v1'
 export const CURRENT_SCHEMA_VERSION = 1 as const
 
 export function createInitialGameState(): PersistedGameState {
@@ -41,20 +42,32 @@ export function migratePersistedState(value: unknown): PersistedGameState | null
       ? value.recentPlayerNames.filter((name): name is string => typeof name === 'string').slice(0, 12)
       : [],
     settings: {
-      ...createDefaultSettings(),
-      ...(value.settings as PersistedGameState['settings']),
-      teamColors: {
-        ...createDefaultSettings().teamColors,
-        ...(isRecord((value.settings as PersistedGameState['settings']).teamColors)
-          ? ((value.settings as PersistedGameState['settings']).teamColors as PersistedGameState['settings']['teamColors'])
-          : {}),
-      },
-      teamNames: {
-        ...createDefaultSettings().teamNames,
-        ...(isRecord((value.settings as PersistedGameState['settings']).teamNames)
-          ? ((value.settings as PersistedGameState['settings']).teamNames as PersistedGameState['settings']['teamNames'])
-          : {}),
-      },
+      ...normalizeSettings(value.settings),
+    },
+  }
+}
+
+export function normalizeSettings(value: unknown): GameSettings {
+  const defaults = createDefaultSettings()
+
+  if (!isRecord(value)) {
+    return defaults
+  }
+
+  return {
+    ...defaults,
+    ...(value as GameSettings),
+    teamColors: {
+      ...defaults.teamColors,
+      ...(isRecord((value as GameSettings).teamColors)
+        ? ((value as GameSettings).teamColors as GameSettings['teamColors'])
+        : {}),
+    },
+    teamNames: {
+      ...defaults.teamNames,
+      ...(isRecord((value as GameSettings).teamNames)
+        ? ((value as GameSettings).teamNames as GameSettings['teamNames'])
+        : {}),
     },
   }
 }
@@ -73,16 +86,50 @@ export function serializeGameState(state: PersistedGameState): string {
 
 export function loadGameState(storage: Storage): PersistedGameState {
   const savedValue = storage.getItem(STORAGE_KEY)
+  const persistedSettings = loadSettings(storage)
 
   if (!savedValue) {
-    return createInitialGameState()
+    return {
+      ...createInitialGameState(),
+      settings: persistedSettings,
+    }
   }
 
-  return deserializeGameState(savedValue) ?? createInitialGameState()
+  const state = deserializeGameState(savedValue)
+
+  if (!state) {
+    return {
+      ...createInitialGameState(),
+      settings: persistedSettings,
+    }
+  }
+
+  return {
+    ...state,
+    settings: persistedSettings,
+  }
 }
 
 export function saveGameState(storage: Storage, state: PersistedGameState): void {
   storage.setItem(STORAGE_KEY, serializeGameState(state))
+}
+
+export function loadSettings(storage: Storage): GameSettings {
+  const savedValue = storage.getItem(SETTINGS_STORAGE_KEY)
+
+  if (!savedValue) {
+    return createDefaultSettings()
+  }
+
+  try {
+    return normalizeSettings(JSON.parse(savedValue))
+  } catch {
+    return createDefaultSettings()
+  }
+}
+
+export function saveSettings(storage: Storage, settings: GameSettings): void {
+  storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
 }
 
 export function clearGameState(storage: Storage): void {


### PR DESCRIPTION
## Summary
- persist language and theme in a dedicated settings storage key and hydrate them on boot
- add regression tests for refresh/remount settings persistence
- reuse the shared dialog close button in the settings dialog to match party setup dialogs

Closes #119
Closes #120

## Checks
- pnpm test src/features/settings/SettingsPanel.test.tsx src/storage/game-storage.test.ts
- pnpm lint
- pnpm test
- pnpm build