### PR TITLE
feat: improve recent player history controls

### DIFF
--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -10,7 +10,7 @@ describe('PartySetup', () => {
 
     if (value) {
       const nextState = JSON.parse(value) as { recentPlayerNames: string[] }
-      nextState.recentPlayerNames = ['Morgan', 'Nova']
+      nextState.recentPlayerNames = ['Morgan', 'Nova', 'Riley', 'Jordan', 'Casey', 'Taylor']
       localStorage.setItem('tichu-board-r1:v1', JSON.stringify(nextState))
     }
   })
@@ -94,6 +94,10 @@ describe('PartySetup', () => {
     expect(screen.getByTestId('team-name-north-south').className).toContain('ring-fuchsia-300/60')
     expect(screen.getByTestId('bench-recent-Morgan')).toBeInTheDocument()
     expect(screen.getByTestId('bench-recent-Nova')).toBeInTheDocument()
+    expect(screen.getByTestId('bench-recent-Riley')).toBeInTheDocument()
+    expect(screen.getByTestId('bench-recent-Jordan')).toBeInTheDocument()
+    expect(screen.getByTestId('bench-recent-Casey')).toBeInTheDocument()
+    expect(screen.queryByTestId('bench-recent-Taylor')).not.toBeInTheDocument()
     expect(screen.getByTestId('team-editor-color-teal')).toBeInTheDocument()
     expect(screen.getByTestId('team-editor-color-orange')).toBeInTheDocument()
     expect(screen.getAllByTestId(/team-editor-color-/)).toHaveLength(7)
@@ -181,6 +185,16 @@ describe('PartySetup', () => {
     await fireEvent.click(screen.getByTestId('seat-west'))
 
     expect(within(screen.getByTestId('seat-west')).getByText('Morgan')).toBeInTheDocument()
+  })
+
+  it('shows recent player names in a separate editor section', async () => {
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByTestId('seat-north'))
+
+    expect(screen.getByText(/recent players|최근 플레이어/i)).toBeInTheDocument()
+    expect(screen.getByText(/drag onto a seat|좌석에 드래그/i)).toBeInTheDocument()
+    expect(within(screen.getByTestId('party-editor-dialog')).getByRole('button', { name: 'Morgan' })).toBeInTheDocument()
   })
 
   it('shows stronger drop targets on other seats when a bench player is armed', async () => {

--- a/src/features/party-setup/PartySetup.tsx
+++ b/src/features/party-setup/PartySetup.tsx
@@ -87,6 +87,8 @@ export function PartySetup() {
           subtitle={controller.t('party.editorSubtitle', { seat: controller.t(`seats.${controller.activePlayer()!.seat}`) })}
           nameFieldLabel={controller.t('party.nameField')}
           quickActionsLabel={controller.t('party.quickActions')}
+          recentNamesLabel={controller.t('party.recentPlayers')}
+          recentNamesHint={controller.t('party.recentPlayersHint')}
           rerollLabel={controller.t('party.rerollName')}
           moveSeatLabel={controller.t('party.moveSeat')}
           closeLabel={controller.t('party.closeEditor')}

--- a/src/features/party-setup/PlayerEditorDialog.tsx
+++ b/src/features/party-setup/PlayerEditorDialog.tsx
@@ -10,6 +10,8 @@ type PlayerEditorDialogProps = {
   subtitle: string
   nameFieldLabel: string
   quickActionsLabel: string
+  recentNamesLabel: string
+  recentNamesHint: string
   rerollLabel: string
   moveSeatLabel: string
   closeLabel: string
@@ -62,6 +64,15 @@ export function PlayerEditorDialog(props: PlayerEditorDialogProps) {
               >
                 {props.moveSeatLabel}
               </button>
+            </div>
+          </div>
+
+          <div class="grid gap-3 rounded-3xl border border-white/10 bg-black/12 p-4">
+            <div class="grid gap-1">
+              <span class="text-sm text-(--color-muted)">{props.recentNamesLabel}</span>
+              <p class="text-xs leading-5 text-(--color-muted)">{props.recentNamesHint}</p>
+            </div>
+            <div class="flex flex-wrap gap-2">
               <For each={props.recentNames}>
                 {(name) => (
                   <button

--- a/src/features/party-setup/use-party-setup-controller.ts
+++ b/src/features/party-setup/use-party-setup-controller.ts
@@ -26,7 +26,7 @@ export function usePartySetupController() {
   })
   const recentNames = createMemo(() => {
     const seatedNames = new Set(state.players.map((player) => player.name.trim().toLowerCase()))
-    return state.recentPlayerNames.filter((name) => !seatedNames.has(name.trim().toLowerCase())).slice(0, 2)
+    return state.recentPlayerNames.filter((name) => !seatedNames.has(name.trim().toLowerCase())).slice(0, 5)
   })
   const rosterPlayers = createMemo(() =>
     state.players.map((player) => ({

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -13,7 +13,7 @@ type SettingsDialogProps = {
 }
 
 export function SettingsDialog(props: SettingsDialogProps) {
-  const { resetGame, setLanguage, setTheme, state, t } = useGame()
+  const { clearRecentPlayerNames, resetGame, setLanguage, setTheme, state, t } = useGame()
 
   return (
     <Show when={props.isOpen}>
@@ -92,6 +92,14 @@ export function SettingsDialog(props: SettingsDialogProps) {
               }}
             >
               {t('settings.showLanding')}
+            </button>
+
+            <button
+              type="button"
+              class="rounded-2xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-(--color-fg)"
+              onClick={() => clearRecentPlayerNames()}
+            >
+              {t('settings.clearRecentPlayers')}
             </button>
 
             <button

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -55,4 +55,23 @@ describe('SettingsPanel', () => {
     await fireEvent.click(screen.getByRole('button', { name: /설정 열기/i }))
     expect(screen.getByText(/테이블 설정/i)).toBeInTheDocument()
   })
+
+  it('clears recent player history from settings', async () => {
+    const value = localStorage.getItem('tichu-board-r1:v1')
+
+    if (value) {
+      const nextState = JSON.parse(value) as { recentPlayerNames: string[] }
+      nextState.recentPlayerNames = ['Morgan', 'Nova', 'Riley']
+      localStorage.setItem('tichu-board-r1:v1', JSON.stringify(nextState))
+    }
+
+    render(() => <App />)
+
+    await fireEvent.click(screen.getByRole('button', { name: /open settings/i }))
+    await fireEvent.click(screen.getByRole('button', { name: /clear recent players/i }))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('tichu-board-r1:v1')).toContain('"recentPlayerNames":[]')
+    })
+  })
 })

--- a/src/shared/i18n/en.ts
+++ b/src/shared/i18n/en.ts
@@ -149,6 +149,7 @@ export const enDictionary = flatten({
     light: 'Light',
     dark: 'Dark',
     showLanding: 'Show Start Screen',
+    clearRecentPlayers: 'Clear Recent Players',
     reset: 'Reset Game',
     resetConfirm: 'Reset the saved game state?',
   },

--- a/src/shared/i18n/ko.ts
+++ b/src/shared/i18n/ko.ts
@@ -147,6 +147,7 @@ export const koDictionary = flatten({
     light: '라이트',
     dark: '다크',
     showLanding: '시작 화면 보기',
+    clearRecentPlayers: '최근 플레이어 지우기',
     reset: '게임 초기화',
     resetConfirm: '저장된 게임 상태를 초기화할까요?',
   },

--- a/src/state/game-context-actions.ts
+++ b/src/state/game-context-actions.ts
@@ -29,6 +29,7 @@ export function createGameActions(options: CreateGameActionsOptions): Pick<
   | 'setTeamName'
   | 'setLanguage'
   | 'setTheme'
+  | 'clearRecentPlayerNames'
   | 'startRound'
   | 'cancelActiveRound'
   | 'addRound'
@@ -94,6 +95,7 @@ export function createGameActions(options: CreateGameActionsOptions): Pick<
         teamNames: applyLanguageTeamNameDefaults(current.teamNames, state.settings.language, language),
       })),
     setTheme: (theme) => setState('settings', 'theme', theme),
+    clearRecentPlayerNames: () => setState('recentPlayerNames', []),
     startRound: () => {
       if (!state.activeRoundStartedAt) {
         setState('activeRoundStartedAt', new Date().toISOString())

--- a/src/state/game-context.shared.ts
+++ b/src/state/game-context.shared.ts
@@ -38,6 +38,7 @@ export type GameContextValue = {
   setTeamName: (teamId: TeamId, name: string) => void
   setLanguage: (language: PersistedGameState['settings']['language']) => void
   setTheme: (theme: ThemeMode) => void
+  clearRecentPlayerNames: () => void
   addRound: (input: RoundInput) => void
   updateRound: (roundId: string, input: RoundInput) => void
   startRound: () => void

--- a/src/state/game-context.tsx
+++ b/src/state/game-context.tsx
@@ -7,7 +7,7 @@ import {
   useContext,
   type ParentComponent,
 } from 'solid-js'
-import { createStore, unwrap } from 'solid-js/store'
+import { createStore } from 'solid-js/store'
 import { calculateCumulativeScores, getGameStatus, getLeadingTeamId } from '@/domain/scoring'
 import { saveGameState, saveSettings } from '@/storage/game-storage'
 import { createTranslator } from '@/shared/i18n'
@@ -43,6 +43,34 @@ export const GameProvider: ParentComponent = (props) => {
       'east-west': state.settings.teamNames['east-west'],
     },
   }))
+  const persistedGameState = createMemo(() => ({
+    schemaVersion: state.schemaVersion,
+    hasStartedGame: state.hasStartedGame,
+    players: state.players.map((player) => ({
+      id: player.id,
+      name: player.name,
+      seat: player.seat,
+    })),
+    rounds: state.rounds.map((round) => ({
+      ...round,
+      input: {
+        ...round.input,
+        tichuCalls: { ...round.input.tichuCalls },
+        cardPoints: round.input.cardPoints ? { ...round.input.cardPoints } : null,
+      },
+      result: {
+        ...round.result,
+        cardPoints: { ...round.result.cardPoints },
+        tichuBonuses: { ...round.result.tichuBonuses },
+        roundTotals: { ...round.result.roundTotals },
+        callResults: round.result.callResults.map((callResult) => ({ ...callResult })),
+      },
+      timing: { ...round.timing },
+    })),
+    activeRoundStartedAt: state.activeRoundStartedAt,
+    recentPlayerNames: [...state.recentPlayerNames],
+    settings: persistedSettings(),
+  }))
   const effectiveTheme = createMemo(() => (state.settings.theme === 'system' ? systemTheme() : state.settings.theme))
 
   const mediaQuery =
@@ -58,7 +86,7 @@ export const GameProvider: ParentComponent = (props) => {
   }
 
   createEffect(() => {
-    saveGameState(window.localStorage, unwrap(state))
+    saveGameState(window.localStorage, persistedGameState())
   })
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- show up to five recent player names in party setup and the player editor
- add a settings action to clear saved recent player names
- split the player editor recent-name list into its own section box away from quick actions

Closes #122

## Checks
- pnpm test src/features/party-setup/PartySetup.test.tsx src/features/settings/SettingsPanel.test.tsx
- pnpm lint
- pnpm test
- pnpm build