### PR TITLE
test: fix release scroll expectation

### DIFF
--- a/src/features/party-setup/PartySetup.test.tsx
+++ b/src/features/party-setup/PartySetup.test.tsx
@@ -288,7 +288,7 @@ describe('PartySetup', () => {
     await fireEvent.click(screen.getByTestId('bench-player-player-1'))
 
     expect(window.scrollTo).toHaveBeenCalledWith({
-      top: 412,
+      top: 432,
       behavior: 'smooth',
     })
 


### PR DESCRIPTION
## Summary
- fix the stale PartySetup scroll expectation that breaks the release pipeline
- align the test with the current dock-aware seat map scroll behavior

## Root cause
- the implementation now scrolls to 432
- the test still expected 412
- release workflow runs the full test suite on the release branch, so Pages deployment stopped in the build job

## Testing
- pnpm test src/features/party-setup/PartySetup.test.tsx
- pnpm lint
- pnpm build